### PR TITLE
kvm: fix arm64 interupts and add debugging

### DIFF
--- a/internal/hv/kvm/kvm_arm64.go
+++ b/internal/hv/kvm/kvm_arm64.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"unsafe"
 
+	"github.com/tinyrange/cc/internal/debug"
 	"github.com/tinyrange/cc/internal/hv"
 	"golang.org/x/sys/unix"
 )
@@ -204,6 +205,8 @@ func (v *virtualCPU) handleMMIO(mmioData *kvmExitMMIOData) error {
 }
 
 func (hv *hypervisor) archVMInit(vm *virtualMachine, config hv.VMConfig) error {
+	debug.Writef("kvm hypervisor archVMInit", "")
+
 	if !config.NeedsInterruptSupport() {
 		return nil
 	}
@@ -218,6 +221,8 @@ func (hv *hypervisor) archVMInit(vm *virtualMachine, config hv.VMConfig) error {
 // archPostVCPUInit is called after all vCPUs are created.
 // On ARM64, we need to finalize the vGIC after vCPUs exist.
 func (hv *hypervisor) archPostVCPUInit(vm *virtualMachine, config hv.VMConfig) error {
+	debug.Writef("kvm hypervisor archPostVCPUInit", "")
+
 	if !config.NeedsInterruptSupport() {
 		return nil
 	}
@@ -230,6 +235,8 @@ func (hv *hypervisor) archPostVCPUInit(vm *virtualMachine, config hv.VMConfig) e
 }
 
 func (hv *hypervisor) archVCPUInit(vm *virtualMachine, vcpuFd int) error {
+	debug.Writef("kvm hypervisor archVCPUInit", "vcpuFd: %d", vcpuFd)
+
 	init, err := armPreferredTarget(vm.vmFd)
 	if err != nil {
 		return fmt.Errorf("getting preferred target: %w", err)
@@ -245,6 +252,8 @@ func (hv *hypervisor) archVCPUInit(vm *virtualMachine, vcpuFd int) error {
 }
 
 func enableArmVcpuFeature(init *kvmVcpuInit, feature uint32) {
+	debug.Writef("kvm hypervisor enableArmVcpuFeature", "feature: %d", feature)
+
 	word := feature / 32
 	bit := feature % 32
 

--- a/internal/hv/kvm/kvm_arm64_vgic.go
+++ b/internal/hv/kvm/kvm_arm64_vgic.go
@@ -32,7 +32,7 @@ func (hv *hypervisor) initArm64VGIC(vm *virtualMachine) error {
 	if err := hv.initArm64VGICv3(vm); err != nil {
 		debug.Writef("kvm hypervisor initArm64VGIC v3 failed", "initArm64VGICv3 failed: %v", err)
 		if errors.Is(err, errArmVGICUnsupported) {
-			debug.Writef("kvm hypervisor initArm64VGIC v2 fallback", "initArm64VGICv2 failed, falling back to v2")
+			debug.Writef("kvm hypervisor initArm64VGIC v2 fallback", "initArm64VGICv3 unsupported, falling back to v2")
 			return hv.initArm64VGICv2(vm)
 		}
 		return err

--- a/internal/hv/kvm/kvm_gsi.go
+++ b/internal/hv/kvm/kvm_gsi.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"unsafe"
 
+	"github.com/tinyrange/cc/internal/debug"
 	"golang.org/x/sys/unix"
 )
 
@@ -13,6 +14,8 @@ import (
 // This mirrors what QEMU does for in-kernel irqchip: each GSI is mapped to the
 // in-kernel IOAPIC with the same pin number.
 func initGSIRouting(vmFd int, systemFd int, numGSIs int) error {
+	debug.Writef("kvm hypervisor initGSIRouting", "vmFd: %d, systemFd: %d, numGSIs: %d", vmFd, systemFd, numGSIs)
+
 	if numGSIs <= 0 {
 		return nil
 	}
@@ -86,6 +89,8 @@ const (
 )
 
 func setIrqRouting(vmFd int, table *kvmIrqRouting) error {
+	debug.Writef("kvm hypervisor setIrqRouting", "vmFd: %d, table: %+v", vmFd, table)
+
 	// The KVM_SET_GSI_ROUTING ioctl expects the entries to be inline after the header.
 	headerSize := int(unsafe.Sizeof(kvmIrqRoutingHeader{}))
 	size := headerSize + len(table.Entries)*int(unsafe.Sizeof(kvmIrqRoutingEntry{}))
@@ -110,9 +115,14 @@ func setIrqRouting(vmFd int, table *kvmIrqRouting) error {
 }
 
 func checkExtension(systemFd int, cap int) (bool, error) {
+	debug.Writef("kvm hypervisor checkExtension", "systemFd: %d, cap: %d", systemFd, cap)
+
 	ret, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(systemFd), uintptr(kvmCheckExtension), uintptr(cap))
 	if err != 0 {
 		return false, err
 	}
+
+	debug.Writef("kvm hypervisor checkExtension", "ret: %d", ret)
+
 	return ret != 0, nil
 }

--- a/internal/hv/kvm/kvm_irq.go
+++ b/internal/hv/kvm/kvm_irq.go
@@ -5,10 +5,13 @@ package kvm
 import (
 	"fmt"
 
+	"github.com/tinyrange/cc/internal/debug"
 	"github.com/tinyrange/cc/internal/hv"
 )
 
 func (v *virtualMachine) SetIRQ(irqLine uint32, level bool) error {
+	debug.Writef("kvm hypervisor SetIRQ", "irqLine: %d, level: %v", irqLine, level)
+
 	if v == nil {
 		return fmt.Errorf("kvm: virtual machine is nil")
 	}
@@ -49,6 +52,8 @@ func (v *virtualMachine) SetIRQ(irqLine uint32, level bool) error {
 // destMode: 0 for Physical, 1 for Logical
 // deliveryMode: 0 for Fixed, 1 for LowestPriority, etc.
 func (v *virtualMachine) InjectInterrupt(vector, dest, destMode, deliveryMode uint8) error {
+	debug.Writef("kvm hypervisor InjectInterrupt", "vector: %d, dest: %d, destMode: %d, deliveryMode: %d", vector, dest, destMode, deliveryMode)
+
 	if v == nil {
 		return fmt.Errorf("kvm: virtual machine is nil")
 	}

--- a/internal/hv/kvm/kvm_irq_arm64_test.go
+++ b/internal/hv/kvm/kvm_irq_arm64_test.go
@@ -1,0 +1,24 @@
+//go:build linux && arm64
+
+package kvm
+
+import "testing"
+
+func TestArm64KVMIRQFromEncodedIRQLine_SPIAddsBase(t *testing.T) {
+	// SPI offset 8 should become GIC INTID 40 (32 + 8).
+	const encoded = (kvmArmIRQTypeSPI << armIRQTypeShift) | 8
+
+	kvmIRQ, irqType, intid, err := arm64KVMIRQFromEncodedIRQLine(encoded)
+	if err != nil {
+		t.Fatalf("arm64KVMIRQFromEncodedIRQLine: %v", err)
+	}
+	if irqType != kvmArmIRQTypeSPI {
+		t.Fatalf("irqType=%d, want %d", irqType, kvmArmIRQTypeSPI)
+	}
+	if intid != 40 {
+		t.Fatalf("intid=%d, want 40", intid)
+	}
+	if kvmIRQ != ((kvmArmIRQTypeSPI << armIRQTypeShift) | 40) {
+		t.Fatalf("kvmIRQ=%#x, want %#x", kvmIRQ, (kvmArmIRQTypeSPI<<armIRQTypeShift)|40)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Corrects ARM64 interrupt delivery and adds structured debug logging across KVM.
> 
> - Fixes ARM64 IRQ encoding by converting SPI offsets to GIC INTIDs in `arm64KVMIRQFromEncodedIRQLine`; `SetIRQ` now uses the computed INTID; adds unit test
> - Implements ARM64 vGIC init/finalize: prefer v3, fallback to v2; set NR IRQs and distributor/redistributor/CPU iface via device attributes; defer `CTRL_INIT` until after vCPUs; record `Arm64GICInfo`
> - Adds concise debug logs to VM/VCPU init, vGIC setup, GSI routing, IRQ injection/leveling, and KVM capability checks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit faea427f5a4efd8d290e265b3d1d148328ce2bea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->