### PR TITLE
kvm: support apple m1 on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ CrumbleCracker is a high performance embeddable virtualization platform designed
 
 - [x] Fix macOS arm64
 - [ ] Fix Windows amd64
-- [ ] Fix Linux arm64
+- [x] Fix Linux arm64
 - [ ] Fix Windows arm64
 - [ ] Get a more advanced desktop running (like XFCE)
 - [ ] Fix Linux Compile Errors (issues with Virtio-fs)

--- a/internal/hv/kvm/kvm.go
+++ b/internal/hv/kvm/kvm.go
@@ -490,7 +490,7 @@ func (h *hypervisor) NewVirtualMachine(config hv.VMConfig) (hv.VirtualMachine, e
 		vcpus: make(map[int]*virtualCPU),
 	}
 
-	// On M1 this fails unless an atgument is passed to set the IPA size.
+	// On M1 this fails unless an argument is passed to set the IPA size.
 	var ipaSize uint32 = 0
 	if runtime.GOARCH == "arm64" {
 		cap, err := checkExtension(h.fd, kvmCapArmVmIpaSize)

--- a/internal/hv/kvm/kvm_defs.go
+++ b/internal/hv/kvm/kvm_defs.go
@@ -9,6 +9,7 @@ const (
 
 	kvmGetApiVersion          = 0xae00
 	kvmCreateVm               = 0xae01
+	kvmGetCap                 = 0xae02
 	kvmGetMsrIndexList        = 0xc004ae02
 	kvmCheckExtension         = 0xae03
 	kvmGetVcpuMmapSize        = 0xae04
@@ -63,6 +64,8 @@ const (
 	kvmDevTypeArmVgicV3 = 7
 
 	kvmCapSplitIrqchip = 121
+
+	kvmCapArmVmIpaSize = 165
 )
 
 type kvmEnableCapArgs struct {

--- a/internal/hv/kvm/kvm_gsi.go
+++ b/internal/hv/kvm/kvm_gsi.go
@@ -22,7 +22,7 @@ func initGSIRouting(vmFd int, systemFd int, numGSIs int) error {
 
 	if ok, err := checkExtension(systemFd, kvmCapIrqRouting); err != nil {
 		return fmt.Errorf("check KVM_CAP_IRQ_ROUTING: %w", err)
-	} else if !ok {
+	} else if ok == 0 {
 		return nil
 	}
 
@@ -112,17 +112,4 @@ func setIrqRouting(vmFd int, table *kvmIrqRouting) error {
 		return e
 	}
 	return nil
-}
-
-func checkExtension(systemFd int, cap int) (bool, error) {
-	debug.Writef("kvm hypervisor checkExtension", "systemFd: %d, cap: %d", systemFd, cap)
-
-	ret, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(systemFd), uintptr(kvmCheckExtension), uintptr(cap))
-	if err != 0 {
-		return false, err
-	}
-
-	debug.Writef("kvm hypervisor checkExtension", "ret: %d", ret)
-
-	return ret != 0, nil
 }


### PR DESCRIPTION
Turns out a small change to KVM_CREATE_VM is required on M! macs due to addressing things.