### PR TITLE
refactor: add explicit UI widget framework for ccapp graphics

### DIFF
--- a/cmd/ccapp/ui_screens.go
+++ b/cmd/ccapp/ui_screens.go
@@ -1,0 +1,437 @@
+package main
+
+import (
+	"image/color"
+	"path/filepath"
+	"time"
+
+	"github.com/tinyrange/cc/internal/gowin/graphics"
+	"github.com/tinyrange/cc/internal/gowin/ui"
+)
+
+// UI color constants matching the original design
+var (
+	colorBackground    = color.RGBA{R: 10, G: 10, B: 10, A: 255}
+	colorTopBar        = color.RGBA{R: 22, G: 22, B: 22, A: 255}
+	colorBtnNormal     = color.RGBA{R: 40, G: 40, B: 40, A: 255}
+	colorBtnHover      = color.RGBA{R: 56, G: 56, B: 56, A: 255}
+	colorBtnPressed    = color.RGBA{R: 72, G: 72, B: 72, A: 255}
+	colorBorderNormal  = color.RGBA{R: 80, G: 80, B: 80, A: 255}
+	colorBorderHover   = color.RGBA{R: 140, G: 140, B: 140, A: 255}
+	colorBorderPressed = color.RGBA{R: 180, G: 180, B: 180, A: 255}
+	colorCardBg        = color.RGBA{R: 20, G: 20, B: 20, A: 220}
+	colorCardBgHover   = color.RGBA{R: 30, G: 30, B: 30, A: 235}
+	colorOverlay       = color.RGBA{R: 10, G: 10, B: 10, A: 200}
+	colorScrollTrack   = color.RGBA{R: 48, G: 48, B: 48, A: 255}
+	colorScrollThumb   = color.RGBA{R: 100, G: 100, B: 100, A: 255}
+)
+
+// LauncherScreen manages the launcher UI state and widgets
+type LauncherScreen struct {
+	root *ui.Root
+	app  *Application
+
+	// Widgets that need updating
+	bundleCards []*bundleCardWidget
+	scrollView  *ui.ScrollView
+	logo        *ui.AnimatedLogo
+
+	// State
+	scrollX float32
+}
+
+// bundleCardWidget represents a single bundle card
+type bundleCardWidget struct {
+	card  *ui.Card
+	index int
+}
+
+// NewLauncherScreen creates the launcher screen UI
+func NewLauncherScreen(app *Application) *LauncherScreen {
+	screen := &LauncherScreen{
+		root: ui.NewRoot(app.text),
+		app:  app,
+	}
+	screen.buildUI()
+	return screen
+}
+
+func (s *LauncherScreen) buildUI() {
+	// Create the logo widget
+	if s.app.logo != nil {
+		s.logo = ui.NewAnimatedLogo(s.app.logo).WithSize(400, 400)
+	}
+
+	// Main layout: Stack with background, logo, and content
+	stack := ui.NewStack()
+
+	// Background
+	stack.AddChild(ui.NewBox(colorBackground))
+
+	// Logo in bottom-right (only if we have bundles, otherwise it's too prominent)
+	if s.logo != nil {
+		stack.AddChild(ui.BottomRight(
+			ui.NewPadding(s.logo, ui.Only(0, 0, -140, -140)), // Offset to position partly off-screen
+		))
+	}
+
+	// Main content column
+	contentCol := ui.Column()
+
+	// Top bar with Debug Logs button
+	topBar := s.buildTopBar()
+	contentCol.AddChild(topBar, ui.DefaultFlexParams())
+
+	// Title section
+	titleSection := s.buildTitleSection()
+	contentCol.AddChild(titleSection, ui.DefaultFlexParams())
+
+	// Bundle cards section (only if bundles exist)
+	if len(s.app.bundles) > 0 {
+		bundleSection := s.buildBundleSection()
+		contentCol.AddChild(bundleSection, ui.FlexParams(1))
+	}
+
+	stack.AddChild(contentCol)
+	s.root.SetChild(stack)
+}
+
+func (s *LauncherScreen) buildTopBar() *ui.FlexContainer {
+	return ui.Row().
+		WithBackground(colorTopBar).
+		WithPadding(ui.Symmetric(20, 6)).
+		AddChild(ui.NewSpacer(), ui.FlexParams(1)).
+		AddChild(
+			ui.NewButton("Debug Logs").
+				WithMinSize(120, 20).
+				OnClick(func() {
+					s.app.openLogs()
+				}),
+			ui.DefaultFlexParams(),
+		)
+}
+
+func (s *LauncherScreen) buildTitleSection() *ui.FlexContainer {
+	col := ui.Column().
+		WithPadding(ui.Only(20, 50, 20, 0))
+
+	col.AddChild(ui.NewLabel("CrumbleCracker").WithSize(48), ui.DefaultFlexParams())
+
+	if len(s.app.bundles) == 0 {
+		col.AddChild(
+			ui.NewLabel("No bundles found. Create bundles with: cc -build <outDir> <image>").WithSize(20),
+			ui.FlexParamsWithMargin(0, ui.Only(0, 10, 0, 0)),
+		)
+		col.AddChild(
+			ui.NewLabel("Searched for bundles in: "+s.app.bundlesDir).WithSize(20),
+			ui.FlexParamsWithMargin(0, ui.Only(0, 10, 0, 0)),
+		)
+	} else {
+		col.AddChild(
+			ui.NewLabel("Please select an environment to boot").WithSize(20),
+			ui.FlexParamsWithMargin(0, ui.Only(0, 10, 0, 0)),
+		)
+	}
+
+	return col
+}
+
+func (s *LauncherScreen) buildBundleSection() ui.Widget {
+	// Stack with overlay and content
+	stack := ui.NewStack()
+
+	// Semi-transparent overlay
+	stack.AddChild(ui.NewBox(colorOverlay).WithSize(0, 320)) // Height will be constrained
+
+	// Horizontal scrollable card container
+	cardContainer := s.buildCardContainer()
+	s.scrollView = ui.NewScrollView(cardContainer).
+		WithHorizontalOnly().
+		WithScrollbarWidth(8)
+
+	// Wrap in a column with fixed height and scrollbar below
+	bundleCol := ui.Column().
+		WithPadding(ui.Only(20, 0, 20, 20))
+
+	bundleCol.AddChild(s.scrollView, ui.FlexParams(1))
+
+	stack.AddChild(bundleCol)
+
+	return stack
+}
+
+func (s *LauncherScreen) buildCardContainer() *ui.FlexContainer {
+	row := ui.Row().WithGap(24)
+
+	s.bundleCards = nil
+	for i, b := range s.app.bundles {
+		card := s.buildBundleCard(i, b)
+		s.bundleCards = append(s.bundleCards, card)
+		row.AddChild(card.card, ui.DefaultFlexParams())
+	}
+
+	return row
+}
+
+func (s *LauncherScreen) buildBundleCard(index int, b discoveredBundle) *bundleCardWidget {
+	name := b.Meta.Name
+	if name == "" || name == "{{name}}" {
+		name = filepath.Base(b.Dir)
+	}
+	desc := b.Meta.Description
+	if desc == "" || desc == "{{description}}" {
+		desc = "VM Bundle"
+	}
+
+	// Card content: vertical layout with image area and text
+	content := ui.Column().WithGap(8)
+
+	// Placeholder image area (the card itself provides the visual)
+	content.AddChild(ui.NewSpacer().WithSize(180, 180), ui.DefaultFlexParams())
+
+	// Name and description
+	content.AddChild(ui.NewLabel(name).WithSize(18), ui.DefaultFlexParams())
+	content.AddChild(ui.NewLabel(desc).WithSize(14).WithColor(graphics.ColorLightGray), ui.DefaultFlexParams())
+
+	cardStyle := ui.CardStyle{
+		BackgroundColor: color.RGBA{A: 0}, // Transparent by default
+		BorderColor:     colorBorderNormal,
+		BorderWidth:     1,
+		Padding:         ui.All(0),
+	}
+
+	hoverStyle := ui.CardStyle{
+		BackgroundColor: colorCardBg,
+		BorderColor:     colorBorderHover,
+		BorderWidth:     1,
+		Padding:         ui.All(0),
+	}
+
+	card := ui.NewCard(content).
+		WithStyle(cardStyle).
+		WithHoverStyle(hoverStyle).
+		WithFixedSize(180, 240).
+		OnClick(func() {
+			s.app.selectedIndex = index
+			s.app.startBootBundle(index)
+		})
+
+	return &bundleCardWidget{
+		card:  card,
+		index: index,
+	}
+}
+
+func (s *LauncherScreen) Update(f graphics.Frame) {
+	// Update logo animation
+	if s.logo != nil {
+		t := float32(time.Since(s.app.start).Seconds())
+		s.logo.SetTime(t)
+	}
+	s.root.InvalidateLayout()
+}
+
+func (s *LauncherScreen) Render(f graphics.Frame) error {
+	s.Update(f)
+	s.root.Step(f, s.app.window.PlatformWindow())
+	return nil
+}
+
+// LoadingScreen manages the loading UI state
+type LoadingScreen struct {
+	root *ui.Root
+	app  *Application
+	logo *ui.AnimatedLogo
+}
+
+// NewLoadingScreen creates the loading screen UI
+func NewLoadingScreen(app *Application) *LoadingScreen {
+	screen := &LoadingScreen{
+		root: ui.NewRoot(app.text),
+		app:  app,
+	}
+	screen.buildUI()
+	return screen
+}
+
+func (s *LoadingScreen) buildUI() {
+	// Stack layout
+	stack := ui.NewStack()
+
+	// Background
+	stack.AddChild(ui.NewBox(colorBackground))
+
+	// Centered logo
+	if s.app.logo != nil {
+		s.logo = ui.NewAnimatedLogo(s.app.logo).
+			WithSize(300, 300).
+			WithSpeeds(0.9, -1.4, 2.2)
+		stack.AddChild(ui.CenterCenter(s.logo))
+	}
+
+	// Loading text at top-left
+	msg := "Booting VM…"
+	if s.app.bootName != "" {
+		msg = "Booting " + s.app.bootName + "…"
+	}
+	loadingLabel := ui.NewLabel(msg).WithSize(20)
+	stack.AddChild(ui.TopLeft(ui.NewPadding(loadingLabel, ui.All(20))))
+
+	s.root.SetChild(stack)
+}
+
+func (s *LoadingScreen) Update(f graphics.Frame) {
+	if s.logo != nil {
+		t := float32(time.Since(s.app.bootStarted).Seconds())
+		s.logo.SetTime(t)
+	}
+	s.root.InvalidateLayout()
+}
+
+func (s *LoadingScreen) Render(f graphics.Frame) error {
+	s.Update(f)
+	s.root.Step(f, s.app.window.PlatformWindow())
+	return nil
+}
+
+// ErrorScreen manages the error UI state
+type ErrorScreen struct {
+	root *ui.Root
+	app  *Application
+	logo *ui.AnimatedLogo
+}
+
+// NewErrorScreen creates the error screen UI
+func NewErrorScreen(app *Application) *ErrorScreen {
+	screen := &ErrorScreen{
+		root: ui.NewRoot(app.text),
+		app:  app,
+	}
+	screen.buildUI()
+	return screen
+}
+
+func (s *ErrorScreen) buildUI() {
+	stack := ui.NewStack()
+
+	// Background
+	stack.AddChild(ui.NewBox(colorBackground))
+
+	// Subtle rotating logo in center
+	if s.app.logo != nil {
+		s.logo = ui.NewAnimatedLogo(s.app.logo).
+			WithSize(250, 250).
+			WithSpeeds(0.4, 0, 0) // Only outer circle slowly rotates
+		stack.AddChild(ui.CenterCenter(s.logo))
+	}
+
+	// Content column
+	content := ui.Column().WithPadding(ui.All(30))
+
+	// Error header
+	content.AddChild(ui.NewLabel("Error").WithSize(56), ui.DefaultFlexParams())
+
+	// Error message
+	msg := s.app.errMsg
+	if msg == "" {
+		msg = "unknown error"
+	}
+	content.AddChild(
+		ui.NewLabel(msg).WithSize(18),
+		ui.FlexParamsWithMargin(0, ui.Only(0, 30, 0, 0)),
+	)
+
+	// Buttons
+	buttonCol := ui.Column().WithGap(14)
+
+	buttonCol.AddChild(
+		ui.NewButton("Back to carousel").
+			WithMinSize(320, 44).
+			OnClick(func() {
+				s.app.errMsg = ""
+				s.app.selectedIndex = -1
+				s.app.mode = modeLauncher
+			}),
+		ui.DefaultFlexParams(),
+	)
+
+	buttonCol.AddChild(
+		ui.NewButton("Open logs directory").
+			WithMinSize(320, 44).
+			OnClick(func() {
+				s.app.openLogs()
+			}),
+		ui.DefaultFlexParams(),
+	)
+
+	content.AddChild(buttonCol, ui.FlexParamsWithMargin(0, ui.Only(0, 40, 0, 0)))
+
+	stack.AddChild(content)
+
+	s.root.SetChild(stack)
+}
+
+func (s *ErrorScreen) Update(f graphics.Frame) {
+	if s.logo != nil {
+		t := float32(time.Since(s.app.start).Seconds())
+		s.logo.SetTime(t)
+	}
+	s.root.InvalidateLayout()
+}
+
+func (s *ErrorScreen) Render(f graphics.Frame) error {
+	s.Update(f)
+	s.root.Step(f, s.app.window.PlatformWindow())
+	return nil
+}
+
+// TerminalScreen manages the terminal UI state
+type TerminalScreen struct {
+	root *ui.Root
+	app  *Application
+}
+
+// NewTerminalScreen creates the terminal screen UI (top bar only)
+func NewTerminalScreen(app *Application) *TerminalScreen {
+	screen := &TerminalScreen{
+		root: ui.NewRoot(app.text),
+		app:  app,
+	}
+	screen.buildUI()
+	return screen
+}
+
+func (s *TerminalScreen) buildUI() {
+	// Just the top bar - terminal view is handled separately
+	topBar := ui.Row().
+		WithBackground(colorTopBar).
+		WithPadding(ui.Symmetric(20, 6)).
+		AddChild(
+			ui.NewButton("Exit").
+				WithMinSize(70, 20).
+				OnClick(func() {
+					s.app.stopVM()
+				}),
+			ui.DefaultFlexParams(),
+		).
+		AddChild(ui.NewSpacer(), ui.FlexParams(1)).
+		AddChild(
+			ui.NewButton("Debug Logs").
+				WithMinSize(120, 20).
+				OnClick(func() {
+					s.app.openLogs()
+				}),
+			ui.DefaultFlexParams(),
+		)
+
+	// Wrap in column to set height
+	col := ui.Column()
+	col.AddChild(topBar, ui.DefaultFlexParams())
+	col.AddChild(ui.NewSpacer(), ui.FlexParams(1)) // Rest of space for terminal
+
+	s.root.SetChild(col)
+}
+
+func (s *TerminalScreen) RenderTopBar(f graphics.Frame) {
+	s.root.Step(f, s.app.window.PlatformWindow())
+}

--- a/cmd/ccapp/ui_screens.go
+++ b/cmd/ccapp/ui_screens.go
@@ -129,7 +129,7 @@ func (s *LauncherScreen) buildTitleSection() *ui.FlexContainer {
 	} else {
 		col.AddChild(
 			ui.NewLabel("Please select an environment to boot").WithSize(20),
-			ui.FlexParamsWithMargin(0, ui.Only(0, 10, 0, 0)),
+			ui.FlexParamsWithMargin(0, ui.Only(0, 10, 0, 10)),
 		)
 	}
 
@@ -183,11 +183,16 @@ func (s *LauncherScreen) buildBundleCard(index int, b discoveredBundle) *bundleC
 		desc = "VM Bundle"
 	}
 
+	// Card dimensions and padding
+	const cardWidth = 180
+	const cardHeight = 230
+	const contentWidth = cardWidth - 10
+
 	// Card content: vertical layout with image area and text
 	content := ui.Column().WithGap(8)
 
-	// Placeholder image area (the card itself provides the visual)
-	content.AddChild(ui.NewSpacer().WithSize(180, 180), ui.DefaultFlexParams())
+	// Placeholder image area (sized to fit within padded content area)
+	content.AddChild(ui.NewSpacer().WithSize(contentWidth, contentWidth), ui.DefaultFlexParams())
 
 	// Name and description
 	content.AddChild(ui.NewLabel(name).WithSize(18), ui.DefaultFlexParams())
@@ -197,20 +202,20 @@ func (s *LauncherScreen) buildBundleCard(index int, b discoveredBundle) *bundleC
 		BackgroundColor: color.RGBA{A: 0}, // Transparent by default
 		BorderColor:     colorBorderNormal,
 		BorderWidth:     1,
-		Padding:         ui.All(0),
+		Padding:         ui.Only(5, 0, 5, 0),
 	}
 
 	hoverStyle := ui.CardStyle{
 		BackgroundColor: colorCardBg,
 		BorderColor:     colorBorderHover,
 		BorderWidth:     1,
-		Padding:         ui.All(0),
+		Padding:         ui.Only(5, 0, 5, 0),
 	}
 
 	card := ui.NewCard(content).
 		WithStyle(cardStyle).
 		WithHoverStyle(hoverStyle).
-		WithFixedSize(180, 240).
+		WithFixedSize(cardWidth, cardHeight).
 		OnClick(func() {
 			s.app.selectedIndex = index
 			s.app.startBootBundle(index)

--- a/internal/gowin/ui/button.go
+++ b/internal/gowin/ui/button.go
@@ -1,0 +1,199 @@
+package ui
+
+import (
+	"image/color"
+
+	"github.com/tinyrange/cc/internal/gowin/graphics"
+	"github.com/tinyrange/cc/internal/gowin/window"
+)
+
+// ButtonState tracks button interaction state.
+type ButtonState int
+
+const (
+	ButtonStateNormal ButtonState = iota
+	ButtonStateHovered
+	ButtonStatePressed
+	ButtonStateDisabled
+)
+
+// ButtonStyle defines button appearance.
+type ButtonStyle struct {
+	BackgroundNormal   color.Color
+	BackgroundHovered  color.Color
+	BackgroundPressed  color.Color
+	BackgroundDisabled color.Color
+	TextColor          color.Color
+	TextSize           float64
+	Padding            EdgeInsets
+	MinWidth           float32
+	MinHeight          float32
+}
+
+// DefaultButtonStyle returns the default button styling.
+func DefaultButtonStyle() ButtonStyle {
+	return ButtonStyle{
+		BackgroundNormal:   color.RGBA{R: 40, G: 40, B: 40, A: 255},
+		BackgroundHovered:  color.RGBA{R: 56, G: 56, B: 56, A: 255},
+		BackgroundPressed:  color.RGBA{R: 72, G: 72, B: 72, A: 255},
+		BackgroundDisabled: color.RGBA{R: 30, G: 30, B: 30, A: 255},
+		TextColor:          graphics.ColorWhite,
+		TextSize:           14,
+		Padding:            Symmetric(16, 8),
+		MinWidth:           60,
+		MinHeight:          32,
+	}
+}
+
+// Button is a clickable button widget.
+type Button struct {
+	BaseWidget
+
+	text    string
+	style   ButtonStyle
+	state   ButtonState
+	onClick func()
+
+	// Cached layout
+	textWidth float32
+}
+
+// NewButton creates a new button.
+func NewButton(text string) *Button {
+	b := &Button{
+		BaseWidget: NewBaseWidget(),
+		text:       text,
+		style:      DefaultButtonStyle(),
+		state:      ButtonStateNormal,
+	}
+	b.focusable = true
+	return b
+}
+
+func (b *Button) WithStyle(style ButtonStyle) *Button {
+	b.style = style
+	return b
+}
+
+func (b *Button) WithMinSize(w, h float32) *Button {
+	b.style.MinWidth = w
+	b.style.MinHeight = h
+	return b
+}
+
+func (b *Button) WithPadding(p EdgeInsets) *Button {
+	b.style.Padding = p
+	return b
+}
+
+func (b *Button) OnClick(handler func()) *Button {
+	b.onClick = handler
+	return b
+}
+
+func (b *Button) SetText(text string) {
+	b.text = text
+	b.textWidth = 0 // Force recalculation
+}
+
+func (b *Button) GetText() string {
+	return b.text
+}
+
+func (b *Button) Layout(ctx *LayoutContext, constraints Constraints) Size {
+	// Measure text
+	if ctx.TextRenderer != nil {
+		b.textWidth = ctx.TextRenderer.Advance(b.style.TextSize, b.text)
+	} else {
+		b.textWidth = float32(len(b.text)) * float32(b.style.TextSize) * 0.6
+	}
+
+	w := b.textWidth + b.style.Padding.Left + b.style.Padding.Right
+	h := float32(b.style.TextSize) + b.style.Padding.Top + b.style.Padding.Bottom
+
+	// Apply minimum size
+	if w < b.style.MinWidth {
+		w = b.style.MinWidth
+	}
+	if h < b.style.MinHeight {
+		h = b.style.MinHeight
+	}
+
+	// Clamp to constraints
+	w = clamp(w, constraints.MinW, constraints.MaxW)
+	h = clamp(h, constraints.MinH, constraints.MaxH)
+
+	return Size{W: w, H: h}
+}
+
+func (b *Button) Draw(ctx *DrawContext) {
+	if !b.visible {
+		return
+	}
+
+	bounds := b.Bounds()
+
+	// Determine background color
+	var bg color.Color
+	if !b.enabled {
+		bg = b.style.BackgroundDisabled
+	} else {
+		switch b.state {
+		case ButtonStateHovered:
+			bg = b.style.BackgroundHovered
+		case ButtonStatePressed:
+			bg = b.style.BackgroundPressed
+		default:
+			bg = b.style.BackgroundNormal
+		}
+	}
+
+	// Draw background
+	ctx.Frame.RenderQuad(bounds.X, bounds.Y, bounds.W, bounds.H, nil, bg)
+
+	// Draw text centered
+	if ctx.Text != nil {
+		textX := bounds.X + (bounds.W-b.textWidth)/2
+		textY := bounds.Y + bounds.H/2 + float32(b.style.TextSize)/3
+		ctx.Text.RenderText(b.text, textX, textY, b.style.TextSize, b.style.TextColor)
+	}
+}
+
+func (b *Button) HandleEvent(ctx *EventContext, event Event) bool {
+	if !b.enabled || !b.visible {
+		return false
+	}
+
+	bounds := b.Bounds()
+
+	switch e := event.(type) {
+	case *MouseMoveEvent:
+		isHovered := bounds.Contains(e.X, e.Y)
+		if isHovered {
+			if b.state != ButtonStatePressed {
+				b.state = ButtonStateHovered
+			}
+		} else if b.state == ButtonStateHovered {
+			b.state = ButtonStateNormal
+		}
+		return false // Don't consume move events
+
+	case *MouseButtonEvent:
+		if e.Button != window.ButtonLeft {
+			return false
+		}
+		isInside := bounds.Contains(e.X, e.Y)
+		if e.Pressed && isInside {
+			b.state = ButtonStatePressed
+			return true
+		} else if !e.Pressed && b.state == ButtonStatePressed {
+			b.state = ButtonStateNormal
+			if isInside && b.onClick != nil {
+				b.onClick()
+			}
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/gowin/ui/button.go
+++ b/internal/gowin/ui/button.go
@@ -188,10 +188,13 @@ func (b *Button) HandleEvent(ctx *EventContext, event Event) bool {
 			return true
 		} else if !e.Pressed && b.state == ButtonStatePressed {
 			b.state = ButtonStateNormal
-			if isInside && b.onClick != nil {
-				b.onClick()
+			if isInside {
+				if b.onClick != nil {
+					b.onClick()
+				}
+				return true
 			}
-			return true
+			return false
 		}
 	}
 

--- a/internal/gowin/ui/card.go
+++ b/internal/gowin/ui/card.go
@@ -1,0 +1,217 @@
+package ui
+
+import (
+	"image/color"
+
+	"github.com/tinyrange/cc/internal/gowin/window"
+)
+
+// CardStyle defines card appearance.
+type CardStyle struct {
+	BackgroundColor color.Color
+	BorderColor     color.Color
+	BorderWidth     float32
+	Padding         EdgeInsets
+}
+
+// DefaultCardStyle returns default card styling.
+func DefaultCardStyle() CardStyle {
+	return CardStyle{
+		BackgroundColor: color.RGBA{R: 20, G: 20, B: 20, A: 220},
+		BorderColor:     color.RGBA{R: 80, G: 80, B: 80, A: 255},
+		BorderWidth:     1,
+		Padding:         All(12),
+	}
+}
+
+// Card is a container with visual styling (background, border).
+type Card struct {
+	BaseWidget
+
+	content Widget
+	style   CardStyle
+
+	// Hover state for interactive cards
+	hovered    bool
+	onClick    func()
+	hoverStyle *CardStyle
+
+	// Fixed size (0 = auto)
+	fixedWidth  float32
+	fixedHeight float32
+}
+
+// NewCard creates a new card.
+func NewCard(content Widget) *Card {
+	return &Card{
+		BaseWidget: NewBaseWidget(),
+		content:    content,
+		style:      DefaultCardStyle(),
+	}
+}
+
+func (c *Card) WithStyle(style CardStyle) *Card {
+	c.style = style
+	return c
+}
+
+func (c *Card) WithHoverStyle(style CardStyle) *Card {
+	c.hoverStyle = &style
+	return c
+}
+
+func (c *Card) WithFixedSize(w, h float32) *Card {
+	c.fixedWidth = w
+	c.fixedHeight = h
+	return c
+}
+
+func (c *Card) WithPadding(p EdgeInsets) *Card {
+	c.style.Padding = p
+	return c
+}
+
+func (c *Card) WithBackground(col color.Color) *Card {
+	c.style.BackgroundColor = col
+	return c
+}
+
+func (c *Card) WithBorder(col color.Color, width float32) *Card {
+	c.style.BorderColor = col
+	c.style.BorderWidth = width
+	return c
+}
+
+func (c *Card) OnClick(handler func()) *Card {
+	c.onClick = handler
+	c.focusable = true
+	return c
+}
+
+func (c *Card) SetContent(content Widget) {
+	c.content = content
+}
+
+func (c *Card) IsHovered() bool {
+	return c.hovered
+}
+
+func (c *Card) Layout(ctx *LayoutContext, constraints Constraints) Size {
+	p := c.style.Padding
+
+	// Handle fixed size
+	if c.fixedWidth > 0 && c.fixedHeight > 0 {
+		// Layout content with fixed inner size
+		if c.content != nil {
+			contentConstraints := Constraints{
+				MinW: c.fixedWidth - p.Horizontal(),
+				MaxW: c.fixedWidth - p.Horizontal(),
+				MinH: c.fixedHeight - p.Vertical(),
+				MaxH: c.fixedHeight - p.Vertical(),
+			}
+			c.content.Layout(ctx, contentConstraints)
+		}
+		return Size{W: c.fixedWidth, H: c.fixedHeight}
+	}
+
+	// Subtract padding from constraints for content
+	contentConstraints := Constraints{
+		MinW: max(0, constraints.MinW-p.Horizontal()),
+		MaxW: max(0, constraints.MaxW-p.Horizontal()),
+		MinH: max(0, constraints.MinH-p.Vertical()),
+		MaxH: max(0, constraints.MaxH-p.Vertical()),
+	}
+
+	var contentSize Size
+	if c.content != nil {
+		contentSize = c.content.Layout(ctx, contentConstraints)
+	}
+
+	w := contentSize.W + p.Horizontal()
+	h := contentSize.H + p.Vertical()
+
+	// Apply fixed dimensions if specified
+	if c.fixedWidth > 0 {
+		w = c.fixedWidth
+	}
+	if c.fixedHeight > 0 {
+		h = c.fixedHeight
+	}
+
+	return Size{W: w, H: h}
+}
+
+func (c *Card) SetBounds(bounds Rect) {
+	c.BaseWidget.SetBounds(bounds)
+
+	if c.content != nil {
+		p := c.style.Padding
+		c.content.SetBounds(bounds.Inset(p.Left, p.Top, p.Right, p.Bottom))
+	}
+}
+
+func (c *Card) Draw(ctx *DrawContext) {
+	if !c.visible {
+		return
+	}
+
+	bounds := c.Bounds()
+	style := c.style
+	if c.hovered && c.hoverStyle != nil {
+		style = *c.hoverStyle
+	}
+
+	// Background
+	if style.BackgroundColor != nil {
+		ctx.Frame.RenderQuad(bounds.X, bounds.Y, bounds.W, bounds.H, nil, style.BackgroundColor)
+	}
+
+	// Border
+	if style.BorderWidth > 0 && style.BorderColor != nil {
+		bw := style.BorderWidth
+		bc := style.BorderColor
+		// Top
+		ctx.Frame.RenderQuad(bounds.X, bounds.Y, bounds.W, bw, nil, bc)
+		// Bottom
+		ctx.Frame.RenderQuad(bounds.X, bounds.Y+bounds.H-bw, bounds.W, bw, nil, bc)
+		// Left
+		ctx.Frame.RenderQuad(bounds.X, bounds.Y, bw, bounds.H, nil, bc)
+		// Right
+		ctx.Frame.RenderQuad(bounds.X+bounds.W-bw, bounds.Y, bw, bounds.H, nil, bc)
+	}
+
+	// Content
+	if c.content != nil {
+		c.content.Draw(ctx)
+	}
+}
+
+func (c *Card) HandleEvent(ctx *EventContext, event Event) bool {
+	bounds := c.Bounds()
+
+	switch e := event.(type) {
+	case *MouseMoveEvent:
+		c.hovered = bounds.Contains(e.X, e.Y)
+
+	case *MouseButtonEvent:
+		if e.Button == window.ButtonLeft && e.Pressed && bounds.Contains(e.X, e.Y) {
+			if c.onClick != nil {
+				c.onClick()
+				return true
+			}
+		}
+	}
+
+	// Dispatch to content
+	if c.content != nil {
+		return c.content.HandleEvent(ctx, event)
+	}
+	return false
+}
+
+func (c *Card) Children() []Widget {
+	if c.content != nil {
+		return []Widget{c.content}
+	}
+	return nil
+}

--- a/internal/gowin/ui/container.go
+++ b/internal/gowin/ui/container.go
@@ -335,7 +335,15 @@ func (c *FlexContainer) Draw(ctx *DrawContext) {
 }
 
 func (c *FlexContainer) HandleEvent(ctx *EventContext, event Event) bool {
-	// Dispatch to children in reverse order (top-most first)
+	// For MouseMoveEvent, dispatch to ALL children so they can update hover state
+	if _, isMove := event.(*MouseMoveEvent); isMove {
+		for i := len(c.children) - 1; i >= 0; i-- {
+			c.children[i].HandleEvent(ctx, event)
+		}
+		return false
+	}
+
+	// For other events, dispatch in reverse order (top-most first) and stop when handled
 	for i := len(c.children) - 1; i >= 0; i-- {
 		if c.children[i].HandleEvent(ctx, event) {
 			return true

--- a/internal/gowin/ui/container.go
+++ b/internal/gowin/ui/container.go
@@ -1,0 +1,459 @@
+package ui
+
+import "image/color"
+
+// FlexContainer is a container that lays out children using flexbox rules.
+type FlexContainer struct {
+	BaseWidget
+
+	axis       Axis
+	mainAlign  MainAxisAlignment
+	crossAlign CrossAxisAlignment
+	padding    EdgeInsets
+	gap        float32
+
+	children    []Widget
+	childParams map[WidgetID]FlexLayoutParams
+	childSizes  map[WidgetID]Size
+
+	backgroundColor color.Color
+}
+
+// NewFlexContainer creates a new FlexContainer.
+func NewFlexContainer(axis Axis) *FlexContainer {
+	return &FlexContainer{
+		BaseWidget:  NewBaseWidget(),
+		axis:        axis,
+		mainAlign:   MainAxisStart,
+		crossAlign:  CrossAxisStart,
+		childParams: make(map[WidgetID]FlexLayoutParams),
+		childSizes:  make(map[WidgetID]Size),
+	}
+}
+
+// Row creates a horizontal FlexContainer.
+func Row() *FlexContainer {
+	return NewFlexContainer(AxisHorizontal)
+}
+
+// Column creates a vertical FlexContainer.
+func Column() *FlexContainer {
+	return NewFlexContainer(AxisVertical)
+}
+
+// Builder pattern methods
+
+func (c *FlexContainer) WithPadding(p EdgeInsets) *FlexContainer {
+	c.padding = p
+	return c
+}
+
+func (c *FlexContainer) WithGap(gap float32) *FlexContainer {
+	c.gap = gap
+	return c
+}
+
+func (c *FlexContainer) WithMainAlignment(align MainAxisAlignment) *FlexContainer {
+	c.mainAlign = align
+	return c
+}
+
+func (c *FlexContainer) WithCrossAlignment(align CrossAxisAlignment) *FlexContainer {
+	c.crossAlign = align
+	return c
+}
+
+func (c *FlexContainer) WithBackground(col color.Color) *FlexContainer {
+	c.backgroundColor = col
+	return c
+}
+
+// AddChild adds a child widget with layout parameters.
+func (c *FlexContainer) AddChild(child Widget, params FlexLayoutParams) *FlexContainer {
+	c.children = append(c.children, child)
+	c.childParams[child.ID()] = params
+	return c
+}
+
+// AddChildren adds multiple children with default parameters.
+func (c *FlexContainer) AddChildren(children ...Widget) *FlexContainer {
+	for _, child := range children {
+		c.AddChild(child, DefaultFlexParams())
+	}
+	return c
+}
+
+func (c *FlexContainer) RemoveChild(child Widget) {
+	for i, ch := range c.children {
+		if ch.ID() == child.ID() {
+			c.children = append(c.children[:i], c.children[i+1:]...)
+			delete(c.childParams, child.ID())
+			delete(c.childSizes, child.ID())
+			return
+		}
+	}
+}
+
+func (c *FlexContainer) ClearChildren() {
+	c.children = nil
+	c.childParams = make(map[WidgetID]FlexLayoutParams)
+	c.childSizes = make(map[WidgetID]Size)
+}
+
+func (c *FlexContainer) Children() []Widget {
+	return c.children
+}
+
+// Layout implements the flexbox layout algorithm.
+func (c *FlexContainer) Layout(ctx *LayoutContext, constraints Constraints) Size {
+	if len(c.children) == 0 {
+		w := clamp(c.padding.Horizontal(), constraints.MinW, constraints.MaxW)
+		h := clamp(c.padding.Vertical(), constraints.MinH, constraints.MaxH)
+		return Size{W: w, H: h}
+	}
+
+	// Calculate available space
+	availableMain := c.mainSize(constraints.MaxW, constraints.MaxH) - c.mainPadding() - c.gap*float32(len(c.children)-1)
+	availableCross := c.crossSize(constraints.MaxW, constraints.MaxH) - c.crossPadding()
+
+	// First pass: measure non-flex children
+	var totalFixed float32
+	var totalFlex float32
+
+	for _, child := range c.children {
+		params := c.childParams[child.ID()]
+		margin := params.Margin
+
+		if params.Flex == 0 {
+			// Fixed child - measure with unlimited main axis
+			var childConstraints Constraints
+			if c.axis == AxisHorizontal {
+				childConstraints = Constraints{
+					MinW: 0, MaxW: 1e9,
+					MinH: 0, MaxH: availableCross - margin.Vertical(),
+				}
+			} else {
+				childConstraints = Constraints{
+					MinW: 0, MaxW: availableCross - margin.Horizontal(),
+					MinH: 0, MaxH: 1e9,
+				}
+			}
+
+			size := child.Layout(ctx, childConstraints)
+			c.childSizes[child.ID()] = size
+			totalFixed += c.mainOfSize(size) + c.mainMargin(margin)
+		} else {
+			totalFlex += params.Flex
+		}
+	}
+
+	// Distribute remaining space to flex children
+	remainingMain := availableMain - totalFixed
+	if remainingMain < 0 {
+		remainingMain = 0
+	}
+
+	for _, child := range c.children {
+		params := c.childParams[child.ID()]
+		if params.Flex > 0 {
+			margin := params.Margin
+			flexMain := remainingMain * (params.Flex / totalFlex)
+
+			var childConstraints Constraints
+			if c.axis == AxisHorizontal {
+				childConstraints = Constraints{
+					MinW: flexMain - margin.Horizontal(), MaxW: flexMain - margin.Horizontal(),
+					MinH: 0, MaxH: availableCross - margin.Vertical(),
+				}
+			} else {
+				childConstraints = Constraints{
+					MinW: 0, MaxW: availableCross - margin.Horizontal(),
+					MinH: flexMain - margin.Vertical(), MaxH: flexMain - margin.Vertical(),
+				}
+			}
+
+			// Ensure non-negative constraints
+			if childConstraints.MinW < 0 {
+				childConstraints.MinW = 0
+			}
+			if childConstraints.MaxW < 0 {
+				childConstraints.MaxW = 0
+			}
+			if childConstraints.MinH < 0 {
+				childConstraints.MinH = 0
+			}
+			if childConstraints.MaxH < 0 {
+				childConstraints.MaxH = 0
+			}
+
+			size := child.Layout(ctx, childConstraints)
+			c.childSizes[child.ID()] = size
+		}
+	}
+
+	// Calculate total size
+	var totalMain float32
+	var maxCross float32
+
+	for _, child := range c.children {
+		size := c.childSizes[child.ID()]
+		params := c.childParams[child.ID()]
+		margin := params.Margin
+
+		totalMain += c.mainOfSize(size) + c.mainMargin(margin)
+		cross := c.crossOfSize(size) + c.crossMargin(margin)
+		if cross > maxCross {
+			maxCross = cross
+		}
+	}
+	totalMain += c.gap * float32(len(c.children)-1)
+
+	var resultW, resultH float32
+	if c.axis == AxisHorizontal {
+		resultW = totalMain + c.padding.Horizontal()
+		resultH = maxCross + c.padding.Vertical()
+	} else {
+		resultW = maxCross + c.padding.Horizontal()
+		resultH = totalMain + c.padding.Vertical()
+	}
+
+	return Size{
+		W: clamp(resultW, constraints.MinW, constraints.MaxW),
+		H: clamp(resultH, constraints.MinH, constraints.MaxH),
+	}
+}
+
+func (c *FlexContainer) SetBounds(bounds Rect) {
+	c.BaseWidget.SetBounds(bounds)
+	c.positionChildren()
+}
+
+func (c *FlexContainer) positionChildren() {
+	if len(c.children) == 0 {
+		return
+	}
+
+	bounds := c.Bounds()
+
+	// Calculate total content size and spacing
+	var totalMain float32
+	for _, child := range c.children {
+		size := c.childSizes[child.ID()]
+		params := c.childParams[child.ID()]
+		totalMain += c.mainOfSize(size) + c.mainMargin(params.Margin)
+	}
+	totalMain += c.gap * float32(len(c.children)-1)
+
+	availableMain := c.mainSize(bounds.W, bounds.H) - c.mainPadding()
+	availableCross := c.crossSize(bounds.W, bounds.H) - c.crossPadding()
+	extraSpace := availableMain - totalMain
+	if extraSpace < 0 {
+		extraSpace = 0
+	}
+
+	// Determine starting position based on main axis alignment
+	var mainPos float32
+	var spacing float32
+	switch c.mainAlign {
+	case MainAxisStart:
+		mainPos = c.mainStart(bounds) + c.mainStartPadding()
+	case MainAxisCenter:
+		mainPos = c.mainStart(bounds) + c.mainStartPadding() + extraSpace/2
+	case MainAxisEnd:
+		mainPos = c.mainStart(bounds) + c.mainStartPadding() + extraSpace
+	case MainAxisSpaceBetween:
+		mainPos = c.mainStart(bounds) + c.mainStartPadding()
+		if len(c.children) > 1 {
+			spacing = extraSpace / float32(len(c.children)-1)
+		}
+	case MainAxisSpaceAround:
+		spacing = extraSpace / float32(len(c.children))
+		mainPos = c.mainStart(bounds) + c.mainStartPadding() + spacing/2
+	case MainAxisSpaceEvenly:
+		spacing = extraSpace / float32(len(c.children)+1)
+		mainPos = c.mainStart(bounds) + c.mainStartPadding() + spacing
+	}
+
+	crossStart := c.crossStart(bounds) + c.crossStartPadding()
+
+	// Position each child
+	for i, child := range c.children {
+		size := c.childSizes[child.ID()]
+		params := c.childParams[child.ID()]
+		margin := params.Margin
+
+		mainPos += c.mainStartMargin(margin)
+
+		// Determine cross position based on alignment
+		crossAlign := c.crossAlign
+		if params.Alignment != nil {
+			crossAlign = *params.Alignment
+		}
+
+		var crossPos float32
+		childCross := c.crossOfSize(size)
+		switch crossAlign {
+		case CrossAxisStart:
+			crossPos = crossStart + c.crossStartMargin(margin)
+		case CrossAxisCenter:
+			crossPos = crossStart + (availableCross-childCross)/2
+		case CrossAxisEnd:
+			crossPos = crossStart + availableCross - childCross - c.crossEndMargin(margin)
+		case CrossAxisStretch:
+			crossPos = crossStart + c.crossStartMargin(margin)
+			childCross = availableCross - c.crossMargin(margin)
+		}
+
+		var childBounds Rect
+		if c.axis == AxisHorizontal {
+			childBounds = Rect{X: mainPos, Y: crossPos, W: size.W, H: childCross}
+		} else {
+			childBounds = Rect{X: crossPos, Y: mainPos, W: childCross, H: size.H}
+		}
+		child.SetBounds(childBounds)
+
+		mainPos += c.mainOfSize(size) + c.mainEndMargin(margin) + c.gap
+		if i < len(c.children)-1 && (c.mainAlign == MainAxisSpaceBetween || c.mainAlign == MainAxisSpaceAround || c.mainAlign == MainAxisSpaceEvenly) {
+			mainPos += spacing
+		}
+	}
+}
+
+func (c *FlexContainer) Draw(ctx *DrawContext) {
+	if !c.visible {
+		return
+	}
+
+	if c.backgroundColor != nil {
+		b := c.Bounds()
+		ctx.Frame.RenderQuad(b.X, b.Y, b.W, b.H, nil, c.backgroundColor)
+	}
+
+	for _, child := range c.children {
+		child.Draw(ctx)
+	}
+}
+
+func (c *FlexContainer) HandleEvent(ctx *EventContext, event Event) bool {
+	// Dispatch to children in reverse order (top-most first)
+	for i := len(c.children) - 1; i >= 0; i-- {
+		if c.children[i].HandleEvent(ctx, event) {
+			return true
+		}
+	}
+	return false
+}
+
+// Helper methods for axis-agnostic calculations
+
+func (c *FlexContainer) mainSize(w, h float32) float32 {
+	if c.axis == AxisHorizontal {
+		return w
+	}
+	return h
+}
+
+func (c *FlexContainer) crossSize(w, h float32) float32 {
+	if c.axis == AxisHorizontal {
+		return h
+	}
+	return w
+}
+
+func (c *FlexContainer) mainOfSize(s Size) float32 {
+	if c.axis == AxisHorizontal {
+		return s.W
+	}
+	return s.H
+}
+
+func (c *FlexContainer) crossOfSize(s Size) float32 {
+	if c.axis == AxisHorizontal {
+		return s.H
+	}
+	return s.W
+}
+
+func (c *FlexContainer) mainPadding() float32 {
+	if c.axis == AxisHorizontal {
+		return c.padding.Horizontal()
+	}
+	return c.padding.Vertical()
+}
+
+func (c *FlexContainer) crossPadding() float32 {
+	if c.axis == AxisHorizontal {
+		return c.padding.Vertical()
+	}
+	return c.padding.Horizontal()
+}
+
+func (c *FlexContainer) mainStartPadding() float32 {
+	if c.axis == AxisHorizontal {
+		return c.padding.Left
+	}
+	return c.padding.Top
+}
+
+func (c *FlexContainer) crossStartPadding() float32 {
+	if c.axis == AxisHorizontal {
+		return c.padding.Top
+	}
+	return c.padding.Left
+}
+
+func (c *FlexContainer) mainMargin(m EdgeInsets) float32 {
+	if c.axis == AxisHorizontal {
+		return m.Horizontal()
+	}
+	return m.Vertical()
+}
+
+func (c *FlexContainer) crossMargin(m EdgeInsets) float32 {
+	if c.axis == AxisHorizontal {
+		return m.Vertical()
+	}
+	return m.Horizontal()
+}
+
+func (c *FlexContainer) mainStartMargin(m EdgeInsets) float32 {
+	if c.axis == AxisHorizontal {
+		return m.Left
+	}
+	return m.Top
+}
+
+func (c *FlexContainer) mainEndMargin(m EdgeInsets) float32 {
+	if c.axis == AxisHorizontal {
+		return m.Right
+	}
+	return m.Bottom
+}
+
+func (c *FlexContainer) crossStartMargin(m EdgeInsets) float32 {
+	if c.axis == AxisHorizontal {
+		return m.Top
+	}
+	return m.Left
+}
+
+func (c *FlexContainer) crossEndMargin(m EdgeInsets) float32 {
+	if c.axis == AxisHorizontal {
+		return m.Bottom
+	}
+	return m.Right
+}
+
+func (c *FlexContainer) mainStart(r Rect) float32 {
+	if c.axis == AxisHorizontal {
+		return r.X
+	}
+	return r.Y
+}
+
+func (c *FlexContainer) crossStart(r Rect) float32 {
+	if c.axis == AxisHorizontal {
+		return r.Y
+	}
+	return r.X
+}

--- a/internal/gowin/ui/context.go
+++ b/internal/gowin/ui/context.go
@@ -1,0 +1,136 @@
+package ui
+
+import (
+	"github.com/tinyrange/cc/internal/gowin/graphics"
+	"github.com/tinyrange/cc/internal/gowin/text"
+	"github.com/tinyrange/cc/internal/gowin/window"
+)
+
+// LayoutContext provides context during the layout phase.
+type LayoutContext struct {
+	TextRenderer *text.Renderer
+	WindowScale  float32
+}
+
+// NewLayoutContext creates a layout context.
+func NewLayoutContext(txt *text.Renderer, scale float32) *LayoutContext {
+	return &LayoutContext{
+		TextRenderer: txt,
+		WindowScale:  scale,
+	}
+}
+
+// DrawContext provides context during the draw phase.
+type DrawContext struct {
+	Frame graphics.Frame
+	Text  *text.Renderer
+}
+
+// EventContext provides context during event handling.
+type EventContext struct {
+	FocusedWidget WidgetID
+	HoveredWidget WidgetID
+}
+
+// Root is the top-level container that manages the widget tree.
+type Root struct {
+	child Widget
+
+	layoutCtx    *LayoutContext
+	inputProc    *InputProcessor
+	eventCtx     *EventContext
+
+	textRenderer *text.Renderer
+
+	needsLayout bool
+	lastWidth   int
+	lastHeight  int
+}
+
+// NewRoot creates a new root container.
+func NewRoot(txt *text.Renderer) *Root {
+	return &Root{
+		layoutCtx:    NewLayoutContext(txt, 1.0),
+		inputProc:    &InputProcessor{},
+		eventCtx:     &EventContext{},
+		textRenderer: txt,
+		needsLayout:  true,
+	}
+}
+
+// SetChild sets the root widget.
+func (r *Root) SetChild(child Widget) {
+	r.child = child
+	r.needsLayout = true
+}
+
+// InvalidateLayout marks the layout as needing recalculation.
+func (r *Root) InvalidateLayout() {
+	r.needsLayout = true
+}
+
+// Update processes input and updates widget state.
+func (r *Root) Update(f graphics.Frame, pw window.Window) {
+	// Update layout context scale
+	r.layoutCtx.WindowScale = pw.Scale()
+
+	// Process input events
+	events := r.inputProc.ProcessFrame(f, pw)
+	for _, event := range events {
+		if r.child != nil {
+			r.child.HandleEvent(r.eventCtx, event)
+		}
+	}
+
+	// Check if window size changed
+	w, h := f.WindowSize()
+	if w != r.lastWidth || h != r.lastHeight {
+		r.needsLayout = true
+		r.lastWidth = w
+		r.lastHeight = h
+	}
+}
+
+// Layout performs layout if needed.
+func (r *Root) Layout(f graphics.Frame) {
+	if !r.needsLayout || r.child == nil {
+		return
+	}
+
+	w, h := f.WindowSize()
+	constraints := Constraints{
+		MinW: float32(w), MaxW: float32(w),
+		MinH: float32(h), MaxH: float32(h),
+	}
+
+	size := r.child.Layout(r.layoutCtx, constraints)
+	r.child.SetBounds(Rect{X: 0, Y: 0, W: size.W, H: size.H})
+
+	r.needsLayout = false
+}
+
+// Draw renders the widget tree.
+func (r *Root) Draw(f graphics.Frame) {
+	if r.child == nil {
+		return
+	}
+
+	w, h := f.WindowSize()
+	if r.textRenderer != nil {
+		r.textRenderer.SetViewport(int32(w), int32(h))
+	}
+
+	ctx := &DrawContext{
+		Frame: f,
+		Text:  r.textRenderer,
+	}
+
+	r.child.Draw(ctx)
+}
+
+// Step is a convenience method that performs update, layout, and draw.
+func (r *Root) Step(f graphics.Frame, pw window.Window) {
+	r.Update(f, pw)
+	r.Layout(f)
+	r.Draw(f)
+}

--- a/internal/gowin/ui/image.go
+++ b/internal/gowin/ui/image.go
@@ -1,0 +1,205 @@
+package ui
+
+import (
+	"image/color"
+
+	"github.com/tinyrange/cc/internal/gowin/graphics"
+)
+
+// ImageScaleMode controls how images are scaled.
+type ImageScaleMode int
+
+const (
+	ImageScaleFit     ImageScaleMode = iota // Maintain aspect, fit inside
+	ImageScaleFill                          // Maintain aspect, fill container
+	ImageScaleStretch                       // Stretch to fill
+)
+
+// Image displays a texture.
+type Image struct {
+	BaseWidget
+
+	texture graphics.Texture
+
+	// Sizing
+	naturalWidth  float32
+	naturalHeight float32
+	scaleMode     ImageScaleMode
+
+	tintColor color.Color
+}
+
+// NewImage creates an image widget from a texture.
+func NewImage(tex graphics.Texture) *Image {
+	w, h := tex.Size()
+	return &Image{
+		BaseWidget:    NewBaseWidget(),
+		texture:       tex,
+		naturalWidth:  float32(w),
+		naturalHeight: float32(h),
+		scaleMode:     ImageScaleFit,
+		tintColor:     graphics.ColorWhite,
+	}
+}
+
+func (i *Image) WithScaleMode(mode ImageScaleMode) *Image {
+	i.scaleMode = mode
+	return i
+}
+
+func (i *Image) WithTint(c color.Color) *Image {
+	i.tintColor = c
+	return i
+}
+
+func (i *Image) Layout(ctx *LayoutContext, constraints Constraints) Size {
+	// Use natural size clamped to constraints
+	w := clamp(i.naturalWidth, constraints.MinW, constraints.MaxW)
+	h := clamp(i.naturalHeight, constraints.MinH, constraints.MaxH)
+	return Size{W: w, H: h}
+}
+
+func (i *Image) Draw(ctx *DrawContext) {
+	if !i.visible || i.texture == nil {
+		return
+	}
+	bounds := i.Bounds()
+	ctx.Frame.RenderQuad(bounds.X, bounds.Y, bounds.W, bounds.H, i.texture, i.tintColor)
+}
+
+func (i *Image) HandleEvent(ctx *EventContext, event Event) bool {
+	return false
+}
+
+// SVGImage displays an SVG with optional rotation animation.
+type SVGImage struct {
+	BaseWidget
+
+	svg *graphics.SVG
+
+	// Sizing
+	naturalWidth  float32
+	naturalHeight float32
+
+	// Animation
+	rotation float32 // Current rotation in radians
+
+	// For grouped SVG rendering
+	groupName string
+}
+
+// NewSVGImage creates an SVG image widget.
+func NewSVGImage(svg *graphics.SVG) *SVGImage {
+	return &SVGImage{
+		BaseWidget:    NewBaseWidget(),
+		svg:           svg,
+		naturalWidth:  100, // Default size
+		naturalHeight: 100,
+	}
+}
+
+func (s *SVGImage) WithSize(w, h float32) *SVGImage {
+	s.naturalWidth = w
+	s.naturalHeight = h
+	return s
+}
+
+func (s *SVGImage) WithGroup(name string) *SVGImage {
+	s.groupName = name
+	return s
+}
+
+func (s *SVGImage) SetRotation(radians float32) {
+	s.rotation = radians
+}
+
+func (s *SVGImage) Layout(ctx *LayoutContext, constraints Constraints) Size {
+	w := clamp(s.naturalWidth, constraints.MinW, constraints.MaxW)
+	h := clamp(s.naturalHeight, constraints.MinH, constraints.MaxH)
+	return Size{W: w, H: h}
+}
+
+func (s *SVGImage) Draw(ctx *DrawContext) {
+	if !s.visible || s.svg == nil {
+		return
+	}
+	bounds := s.Bounds()
+
+	if s.groupName != "" {
+		s.svg.DrawGroupRotated(ctx.Frame, s.groupName, bounds.X, bounds.Y, bounds.W, bounds.H, s.rotation)
+	} else {
+		s.svg.Draw(ctx.Frame, bounds.X, bounds.Y, bounds.W, bounds.H)
+	}
+}
+
+func (s *SVGImage) HandleEvent(ctx *EventContext, event Event) bool {
+	return false
+}
+
+// AnimatedLogo is a specialized widget for the rotating logo with multiple groups.
+type AnimatedLogo struct {
+	BaseWidget
+
+	svg    *graphics.SVG
+	width  float32
+	height float32
+
+	// Per-group rotation speeds
+	innerSpeed float32
+	morseSpeed float32
+	outerSpeed float32
+
+	// Current time for animation
+	time float32
+}
+
+// NewAnimatedLogo creates an animated logo widget.
+func NewAnimatedLogo(svg *graphics.SVG) *AnimatedLogo {
+	return &AnimatedLogo{
+		BaseWidget: NewBaseWidget(),
+		svg:        svg,
+		width:      200,
+		height:     200,
+		innerSpeed: 0.4,
+		morseSpeed: -0.9,
+		outerSpeed: 1.6,
+	}
+}
+
+func (a *AnimatedLogo) WithSize(w, h float32) *AnimatedLogo {
+	a.width = w
+	a.height = h
+	return a
+}
+
+func (a *AnimatedLogo) WithSpeeds(inner, morse, outer float32) *AnimatedLogo {
+	a.innerSpeed = inner
+	a.morseSpeed = morse
+	a.outerSpeed = outer
+	return a
+}
+
+func (a *AnimatedLogo) SetTime(t float32) {
+	a.time = t
+}
+
+func (a *AnimatedLogo) Layout(ctx *LayoutContext, constraints Constraints) Size {
+	w := clamp(a.width, constraints.MinW, constraints.MaxW)
+	h := clamp(a.height, constraints.MinH, constraints.MaxH)
+	return Size{W: w, H: h}
+}
+
+func (a *AnimatedLogo) Draw(ctx *DrawContext) {
+	if !a.visible || a.svg == nil {
+		return
+	}
+	bounds := a.Bounds()
+
+	a.svg.DrawGroupRotated(ctx.Frame, "inner-circle", bounds.X, bounds.Y, bounds.W, bounds.H, a.time*a.innerSpeed)
+	a.svg.DrawGroupRotated(ctx.Frame, "morse-circle", bounds.X, bounds.Y, bounds.W, bounds.H, a.time*a.morseSpeed)
+	a.svg.DrawGroupRotated(ctx.Frame, "outer-circle", bounds.X, bounds.Y, bounds.W, bounds.H, a.time*a.outerSpeed)
+}
+
+func (a *AnimatedLogo) HandleEvent(ctx *EventContext, event Event) bool {
+	return false
+}

--- a/internal/gowin/ui/input.go
+++ b/internal/gowin/ui/input.go
@@ -1,0 +1,123 @@
+package ui
+
+import (
+	"github.com/tinyrange/cc/internal/gowin/graphics"
+	"github.com/tinyrange/cc/internal/gowin/window"
+)
+
+// Event is the base interface for all UI events.
+type Event interface {
+	isEvent()
+}
+
+// MouseMoveEvent represents cursor movement.
+type MouseMoveEvent struct {
+	X, Y float32
+}
+
+func (*MouseMoveEvent) isEvent() {}
+
+// MouseButtonEvent represents a mouse button press/release.
+type MouseButtonEvent struct {
+	X, Y    float32
+	Button  window.Button
+	Pressed bool
+}
+
+func (*MouseButtonEvent) isEvent() {}
+
+// ScrollEvent represents a scroll wheel event.
+type ScrollEvent struct {
+	X, Y           float32
+	DeltaX, DeltaY float32
+}
+
+func (*ScrollEvent) isEvent() {}
+
+// KeyEvent represents a keyboard event.
+type KeyEvent struct {
+	Key     window.Key
+	Pressed bool
+	Repeat  bool
+	Mods    window.KeyMods
+}
+
+func (*KeyEvent) isEvent() {}
+
+// TextEvent represents text input.
+type TextEvent struct {
+	Text string
+}
+
+func (*TextEvent) isEvent() {}
+
+// InputProcessor converts platform events to UI events.
+type InputProcessor struct {
+	prevMouseX, prevMouseY float32
+	prevButtons            map[window.Button]bool
+	initialized            bool
+}
+
+// ProcessFrame extracts events from the frame and platform window.
+func (p *InputProcessor) ProcessFrame(f graphics.Frame, pw window.Window) []Event {
+	if !p.initialized {
+		p.prevButtons = make(map[window.Button]bool)
+		p.initialized = true
+	}
+
+	var events []Event
+
+	// Cursor position - always generate move event for hover tracking
+	mx, my := f.CursorPos()
+	events = append(events, &MouseMoveEvent{X: mx, Y: my})
+	p.prevMouseX = mx
+	p.prevMouseY = my
+
+	// Check mouse buttons
+	buttons := []window.Button{window.ButtonLeft, window.ButtonRight, window.ButtonMiddle}
+	for _, btn := range buttons {
+		isDown := f.GetButtonState(btn).IsDown()
+		wasDown := p.prevButtons[btn]
+		if isDown != wasDown {
+			events = append(events, &MouseButtonEvent{
+				X:       mx,
+				Y:       my,
+				Button:  btn,
+				Pressed: isDown,
+			})
+			p.prevButtons[btn] = isDown
+		}
+	}
+
+	// Raw platform events
+	for _, ev := range pw.DrainInputEvents() {
+		switch ev.Type {
+		case window.InputEventScroll:
+			events = append(events, &ScrollEvent{
+				X:      mx,
+				Y:      my,
+				DeltaX: ev.ScrollX,
+				DeltaY: ev.ScrollY,
+			})
+		case window.InputEventKeyDown:
+			events = append(events, &KeyEvent{
+				Key:     ev.Key,
+				Pressed: true,
+				Repeat:  ev.Repeat,
+				Mods:    ev.Mods,
+			})
+		case window.InputEventKeyUp:
+			events = append(events, &KeyEvent{
+				Key:     ev.Key,
+				Pressed: false,
+				Mods:    ev.Mods,
+			})
+		case window.InputEventText:
+			if ev.Text != "" {
+				events = append(events, &TextEvent{Text: ev.Text})
+			}
+		}
+	}
+
+	return events
+}

--- a/internal/gowin/ui/label.go
+++ b/internal/gowin/ui/label.go
@@ -1,0 +1,100 @@
+package ui
+
+import (
+	"image/color"
+
+	"github.com/tinyrange/cc/internal/gowin/graphics"
+)
+
+// LabelStyle defines label appearance.
+type LabelStyle struct {
+	TextColor color.Color
+	TextSize  float64
+}
+
+// DefaultLabelStyle returns default label styling.
+func DefaultLabelStyle() LabelStyle {
+	return LabelStyle{
+		TextColor: graphics.ColorWhite,
+		TextSize:  16,
+	}
+}
+
+// Label displays text.
+type Label struct {
+	BaseWidget
+
+	text  string
+	style LabelStyle
+
+	// Cached measurements
+	textWidth  float32
+	textHeight float32
+}
+
+// NewLabel creates a new label.
+func NewLabel(text string) *Label {
+	return &Label{
+		BaseWidget: NewBaseWidget(),
+		text:       text,
+		style:      DefaultLabelStyle(),
+	}
+}
+
+// Text creates a new label (alias for NewLabel).
+func Text(text string) *Label {
+	return NewLabel(text)
+}
+
+func (l *Label) WithStyle(style LabelStyle) *Label {
+	l.style = style
+	return l
+}
+
+func (l *Label) WithColor(c color.Color) *Label {
+	l.style.TextColor = c
+	return l
+}
+
+func (l *Label) WithSize(size float64) *Label {
+	l.style.TextSize = size
+	return l
+}
+
+func (l *Label) SetText(text string) {
+	l.text = text
+	l.textWidth = 0
+}
+
+func (l *Label) GetText() string {
+	return l.text
+}
+
+func (l *Label) Layout(ctx *LayoutContext, constraints Constraints) Size {
+	if ctx.TextRenderer != nil {
+		l.textWidth = ctx.TextRenderer.Advance(l.style.TextSize, l.text)
+		l.textHeight = ctx.TextRenderer.LineHeight(l.style.TextSize)
+	} else {
+		// Rough estimate if no renderer
+		l.textWidth = float32(len(l.text)) * float32(l.style.TextSize) * 0.6
+		l.textHeight = float32(l.style.TextSize) * 1.2
+	}
+
+	w := clamp(l.textWidth, constraints.MinW, constraints.MaxW)
+	h := clamp(l.textHeight, constraints.MinH, constraints.MaxH)
+
+	return Size{W: w, H: h}
+}
+
+func (l *Label) Draw(ctx *DrawContext) {
+	if !l.visible || ctx.Text == nil {
+		return
+	}
+	bounds := l.Bounds()
+	// Text baseline is at Y + height (approximately)
+	ctx.Text.RenderText(l.text, bounds.X, bounds.Y+l.textHeight*0.85, l.style.TextSize, l.style.TextColor)
+}
+
+func (l *Label) HandleEvent(ctx *EventContext, event Event) bool {
+	return false // Labels don't handle events
+}

--- a/internal/gowin/ui/layout.go
+++ b/internal/gowin/ui/layout.go
@@ -1,0 +1,88 @@
+package ui
+
+// Axis represents the main axis direction.
+type Axis int
+
+const (
+	AxisHorizontal Axis = iota
+	AxisVertical
+)
+
+// MainAxisAlignment controls distribution along the main axis.
+type MainAxisAlignment int
+
+const (
+	MainAxisStart MainAxisAlignment = iota
+	MainAxisCenter
+	MainAxisEnd
+	MainAxisSpaceBetween
+	MainAxisSpaceAround
+	MainAxisSpaceEvenly
+)
+
+// CrossAxisAlignment controls alignment on the cross axis.
+type CrossAxisAlignment int
+
+const (
+	CrossAxisStart CrossAxisAlignment = iota
+	CrossAxisCenter
+	CrossAxisEnd
+	CrossAxisStretch
+)
+
+// EdgeInsets represents padding/margin on all four sides.
+type EdgeInsets struct {
+	Left, Top, Right, Bottom float32
+}
+
+// All creates EdgeInsets with the same value on all sides.
+func All(v float32) EdgeInsets {
+	return EdgeInsets{Left: v, Top: v, Right: v, Bottom: v}
+}
+
+// Symmetric creates EdgeInsets with symmetric horizontal/vertical values.
+func Symmetric(horizontal, vertical float32) EdgeInsets {
+	return EdgeInsets{Left: horizontal, Top: vertical, Right: horizontal, Bottom: vertical}
+}
+
+// Only creates EdgeInsets with specific side values.
+func Only(left, top, right, bottom float32) EdgeInsets {
+	return EdgeInsets{Left: left, Top: top, Right: right, Bottom: bottom}
+}
+
+// Horizontal returns the total horizontal inset.
+func (e EdgeInsets) Horizontal() float32 {
+	return e.Left + e.Right
+}
+
+// Vertical returns the total vertical inset.
+func (e EdgeInsets) Vertical() float32 {
+	return e.Top + e.Bottom
+}
+
+// FlexLayoutParams define how a child participates in flex layout.
+type FlexLayoutParams struct {
+	// Flex is the flex grow factor (0 = no grow).
+	Flex float32
+
+	// Alignment overrides the container's cross-axis alignment for this child.
+	Alignment *CrossAxisAlignment
+
+	// Margin around this child.
+	Margin EdgeInsets
+}
+
+// DefaultFlexParams returns default flex layout parameters.
+func DefaultFlexParams() FlexLayoutParams {
+	return FlexLayoutParams{Flex: 0}
+}
+
+// FlexParams returns flex layout parameters with a specific flex factor.
+func FlexParams(flex float32) FlexLayoutParams {
+	return FlexLayoutParams{Flex: flex}
+}
+
+// FlexParamsWithMargin returns flex params with margin.
+func FlexParamsWithMargin(flex float32, margin EdgeInsets) FlexLayoutParams {
+	return FlexLayoutParams{Flex: flex, Margin: margin}
+}

--- a/internal/gowin/ui/scrollview.go
+++ b/internal/gowin/ui/scrollview.go
@@ -1,0 +1,321 @@
+package ui
+
+import (
+	"image/color"
+
+	"github.com/tinyrange/cc/internal/gowin/window"
+)
+
+// ScrollView provides a scrollable content area.
+type ScrollView struct {
+	BaseWidget
+
+	content Widget
+	scrollX float32
+	scrollY float32
+
+	// Scroll bar state
+	draggingThumbX  bool
+	draggingThumbY  bool
+	thumbDragOffset float32
+
+	// Cached
+	contentSize Size
+
+	// Config
+	scrollbarWidth float32
+	showHorizontal bool
+	showVertical   bool
+
+	// Colors
+	trackColor color.Color
+	thumbColor color.Color
+
+	// Viewport for clipping
+	viewportRect Rect
+}
+
+// NewScrollView creates a new scroll view.
+func NewScrollView(content Widget) *ScrollView {
+	return &ScrollView{
+		BaseWidget:     NewBaseWidget(),
+		content:        content,
+		scrollbarWidth: 8,
+		showVertical:   true,
+		showHorizontal: true,
+		trackColor:     color.RGBA{R: 48, G: 48, B: 48, A: 255},
+		thumbColor:     color.RGBA{R: 100, G: 100, B: 100, A: 255},
+	}
+}
+
+func (s *ScrollView) WithScrollbarWidth(w float32) *ScrollView {
+	s.scrollbarWidth = w
+	return s
+}
+
+func (s *ScrollView) WithVerticalOnly() *ScrollView {
+	s.showHorizontal = false
+	s.showVertical = true
+	return s
+}
+
+func (s *ScrollView) WithHorizontalOnly() *ScrollView {
+	s.showHorizontal = true
+	s.showVertical = false
+	return s
+}
+
+func (s *ScrollView) SetContent(content Widget) {
+	s.content = content
+}
+
+func (s *ScrollView) SetScroll(x, y float32) {
+	s.scrollX = x
+	s.scrollY = y
+	s.clampScroll()
+}
+
+func (s *ScrollView) GetScrollX() float32 {
+	return s.scrollX
+}
+
+func (s *ScrollView) GetScrollY() float32 {
+	return s.scrollY
+}
+
+func (s *ScrollView) Layout(ctx *LayoutContext, constraints Constraints) Size {
+	// Layout content with unlimited constraints to get natural size
+	if s.content != nil {
+		s.contentSize = s.content.Layout(ctx, Unconstrained())
+	}
+
+	// ScrollView takes all available space
+	return Size{
+		W: constraints.MaxW,
+		H: constraints.MaxH,
+	}
+}
+
+func (s *ScrollView) SetBounds(bounds Rect) {
+	s.BaseWidget.SetBounds(bounds)
+	s.viewportRect = bounds
+	s.clampScroll()
+	s.updateContentBounds()
+}
+
+func (s *ScrollView) clampScroll() {
+	bounds := s.Bounds()
+	maxScrollX := max(0, s.contentSize.W-bounds.W)
+	maxScrollY := max(0, s.contentSize.H-bounds.H)
+	s.scrollX = clamp(s.scrollX, 0, maxScrollX)
+	s.scrollY = clamp(s.scrollY, 0, maxScrollY)
+}
+
+func (s *ScrollView) updateContentBounds() {
+	if s.content == nil {
+		return
+	}
+	bounds := s.Bounds()
+	contentBounds := Rect{
+		X: bounds.X - s.scrollX,
+		Y: bounds.Y - s.scrollY,
+		W: s.contentSize.W,
+		H: s.contentSize.H,
+	}
+	s.content.SetBounds(contentBounds)
+}
+
+func (s *ScrollView) Draw(ctx *DrawContext) {
+	if !s.visible {
+		return
+	}
+
+	bounds := s.Bounds()
+
+	// Draw content (relies on natural clipping or scissoring if implemented)
+	if s.content != nil {
+		s.content.Draw(ctx)
+	}
+
+	// Draw scrollbars
+	maxScrollX := max(0, s.contentSize.W-bounds.W)
+	maxScrollY := max(0, s.contentSize.H-bounds.H)
+
+	// Vertical scrollbar
+	if s.showVertical && maxScrollY > 0 {
+		trackRect := Rect{
+			X: bounds.X + bounds.W - s.scrollbarWidth,
+			Y: bounds.Y,
+			W: s.scrollbarWidth,
+			H: bounds.H,
+		}
+		ctx.Frame.RenderQuad(trackRect.X, trackRect.Y, trackRect.W, trackRect.H, nil, s.trackColor)
+
+		thumbH := bounds.H * (bounds.H / s.contentSize.H)
+		if thumbH < 30 {
+			thumbH = 30
+		}
+		thumbY := bounds.Y
+		if maxScrollY > 0 {
+			thumbY = bounds.Y + (bounds.H-thumbH)*(s.scrollY/maxScrollY)
+		}
+		ctx.Frame.RenderQuad(trackRect.X, thumbY, trackRect.W, thumbH, nil, s.thumbColor)
+	}
+
+	// Horizontal scrollbar
+	if s.showHorizontal && maxScrollX > 0 {
+		trackRect := Rect{
+			X: bounds.X,
+			Y: bounds.Y + bounds.H - s.scrollbarWidth,
+			W: bounds.W,
+			H: s.scrollbarWidth,
+		}
+		// Adjust width if vertical scrollbar is also visible
+		if s.showVertical && maxScrollY > 0 {
+			trackRect.W -= s.scrollbarWidth
+		}
+		ctx.Frame.RenderQuad(trackRect.X, trackRect.Y, trackRect.W, trackRect.H, nil, s.trackColor)
+
+		thumbW := trackRect.W * (bounds.W / s.contentSize.W)
+		if thumbW < 30 {
+			thumbW = 30
+		}
+		thumbX := trackRect.X
+		if maxScrollX > 0 {
+			thumbX = trackRect.X + (trackRect.W-thumbW)*(s.scrollX/maxScrollX)
+		}
+		ctx.Frame.RenderQuad(thumbX, trackRect.Y, thumbW, trackRect.H, nil, s.thumbColor)
+	}
+}
+
+func (s *ScrollView) HandleEvent(ctx *EventContext, event Event) bool {
+	bounds := s.Bounds()
+	maxScrollX := max(0, s.contentSize.W-bounds.W)
+	maxScrollY := max(0, s.contentSize.H-bounds.H)
+
+	switch e := event.(type) {
+	case *ScrollEvent:
+		if bounds.Contains(e.X, e.Y) {
+			s.scrollY -= e.DeltaY * 40
+			s.scrollX -= e.DeltaX * 40
+			s.clampScroll()
+			s.updateContentBounds()
+			return true
+		}
+
+	case *MouseButtonEvent:
+		if e.Button == window.ButtonLeft {
+			if e.Pressed {
+				// Check vertical thumb
+				if s.showVertical && maxScrollY > 0 {
+					thumbH := bounds.H * (bounds.H / s.contentSize.H)
+					if thumbH < 30 {
+						thumbH = 30
+					}
+					thumbY := bounds.Y
+					if maxScrollY > 0 {
+						thumbY = bounds.Y + (bounds.H-thumbH)*(s.scrollY/maxScrollY)
+					}
+					thumbRect := Rect{
+						X: bounds.X + bounds.W - s.scrollbarWidth,
+						Y: thumbY,
+						W: s.scrollbarWidth,
+						H: thumbH,
+					}
+					if thumbRect.Contains(e.X, e.Y) {
+						s.draggingThumbY = true
+						s.thumbDragOffset = e.Y - thumbY
+						return true
+					}
+				}
+
+				// Check horizontal thumb
+				if s.showHorizontal && maxScrollX > 0 {
+					trackW := bounds.W
+					if s.showVertical && maxScrollY > 0 {
+						trackW -= s.scrollbarWidth
+					}
+					thumbW := trackW * (bounds.W / s.contentSize.W)
+					if thumbW < 30 {
+						thumbW = 30
+					}
+					thumbX := bounds.X
+					if maxScrollX > 0 {
+						thumbX = bounds.X + (trackW-thumbW)*(s.scrollX/maxScrollX)
+					}
+					thumbRect := Rect{
+						X: thumbX,
+						Y: bounds.Y + bounds.H - s.scrollbarWidth,
+						W: thumbW,
+						H: s.scrollbarWidth,
+					}
+					if thumbRect.Contains(e.X, e.Y) {
+						s.draggingThumbX = true
+						s.thumbDragOffset = e.X - thumbX
+						return true
+					}
+				}
+			} else {
+				s.draggingThumbX = false
+				s.draggingThumbY = false
+			}
+		}
+
+	case *MouseMoveEvent:
+		if s.draggingThumbY && maxScrollY > 0 {
+			thumbH := bounds.H * (bounds.H / s.contentSize.H)
+			if thumbH < 30 {
+				thumbH = 30
+			}
+			newThumbY := clamp(e.Y-s.thumbDragOffset, bounds.Y, bounds.Y+bounds.H-thumbH)
+			if bounds.H-thumbH > 0 {
+				s.scrollY = (newThumbY - bounds.Y) / (bounds.H - thumbH) * maxScrollY
+			}
+			s.clampScroll()
+			s.updateContentBounds()
+			return true
+		}
+		if s.draggingThumbX && maxScrollX > 0 {
+			trackW := bounds.W
+			if s.showVertical && maxScrollY > 0 {
+				trackW -= s.scrollbarWidth
+			}
+			thumbW := trackW * (bounds.W / s.contentSize.W)
+			if thumbW < 30 {
+				thumbW = 30
+			}
+			newThumbX := clamp(e.X-s.thumbDragOffset, bounds.X, bounds.X+trackW-thumbW)
+			if trackW-thumbW > 0 {
+				s.scrollX = (newThumbX - bounds.X) / (trackW - thumbW) * maxScrollX
+			}
+			s.clampScroll()
+			s.updateContentBounds()
+			return true
+		}
+	}
+
+	// Dispatch to content
+	if s.content != nil && bounds.Contains(s.getMousePos(event)) {
+		return s.content.HandleEvent(ctx, event)
+	}
+	return false
+}
+
+func (s *ScrollView) getMousePos(event Event) (float32, float32) {
+	switch e := event.(type) {
+	case *MouseMoveEvent:
+		return e.X, e.Y
+	case *MouseButtonEvent:
+		return e.X, e.Y
+	case *ScrollEvent:
+		return e.X, e.Y
+	}
+	return 0, 0
+}
+
+func (s *ScrollView) Children() []Widget {
+	if s.content != nil {
+		return []Widget{s.content}
+	}
+	return nil
+}

--- a/internal/gowin/ui/scrollview.go
+++ b/internal/gowin/ui/scrollview.go
@@ -296,14 +296,18 @@ func (s *ScrollView) HandleEvent(ctx *EventContext, event Event) bool {
 
 	// Dispatch to content
 	if s.content != nil {
-		// Always dispatch MouseMoveEvent so children can update hover state
-		// even when mouse moves outside the viewport
-		if _, isMove := event.(*MouseMoveEvent); isMove {
+		switch event.(type) {
+		case *MouseMoveEvent:
+			// Always dispatch so children can update hover state
 			return s.content.HandleEvent(ctx, event)
-		}
-		// For other events, only dispatch if mouse is within bounds
-		if bounds.Contains(s.getMousePos(event)) {
+		case *KeyEvent, *TextEvent:
+			// Always dispatch keyboard events (no position info)
 			return s.content.HandleEvent(ctx, event)
+		default:
+			// For mouse events, only dispatch if within bounds
+			if bounds.Contains(s.getMousePos(event)) {
+				return s.content.HandleEvent(ctx, event)
+			}
 		}
 	}
 	return false

--- a/internal/gowin/ui/scrollview.go
+++ b/internal/gowin/ui/scrollview.go
@@ -295,8 +295,16 @@ func (s *ScrollView) HandleEvent(ctx *EventContext, event Event) bool {
 	}
 
 	// Dispatch to content
-	if s.content != nil && bounds.Contains(s.getMousePos(event)) {
-		return s.content.HandleEvent(ctx, event)
+	if s.content != nil {
+		// Always dispatch MouseMoveEvent so children can update hover state
+		// even when mouse moves outside the viewport
+		if _, isMove := event.(*MouseMoveEvent); isMove {
+			return s.content.HandleEvent(ctx, event)
+		}
+		// For other events, only dispatch if mouse is within bounds
+		if bounds.Contains(s.getMousePos(event)) {
+			return s.content.HandleEvent(ctx, event)
+		}
 	}
 	return false
 }

--- a/internal/gowin/ui/spacer.go
+++ b/internal/gowin/ui/spacer.go
@@ -194,6 +194,9 @@ type Center struct {
 	BaseWidget
 
 	content Widget
+
+	// Cached content size from Layout
+	contentSize Size
 }
 
 // NewCenter creates a centering wrapper.
@@ -206,7 +209,7 @@ func NewCenter(content Widget) *Center {
 
 func (c *Center) Layout(ctx *LayoutContext, constraints Constraints) Size {
 	if c.content != nil {
-		c.content.Layout(ctx, Unconstrained())
+		c.contentSize = c.content.Layout(ctx, Unconstrained())
 	}
 	return Size{W: constraints.MaxW, H: constraints.MaxH}
 }
@@ -214,10 +217,10 @@ func (c *Center) Layout(ctx *LayoutContext, constraints Constraints) Size {
 func (c *Center) SetBounds(bounds Rect) {
 	c.BaseWidget.SetBounds(bounds)
 	if c.content != nil {
-		contentBounds := c.content.Bounds()
-		x := bounds.X + (bounds.W-contentBounds.W)/2
-		y := bounds.Y + (bounds.H-contentBounds.H)/2
-		c.content.SetBounds(Rect{X: x, Y: y, W: contentBounds.W, H: contentBounds.H})
+		// Use cached size from Layout, not Bounds (which may not be set yet)
+		x := bounds.X + (bounds.W-c.contentSize.W)/2
+		y := bounds.Y + (bounds.H-c.contentSize.H)/2
+		c.content.SetBounds(Rect{X: x, Y: y, W: c.contentSize.W, H: c.contentSize.H})
 	}
 }
 

--- a/internal/gowin/ui/spacer.go
+++ b/internal/gowin/ui/spacer.go
@@ -1,0 +1,295 @@
+package ui
+
+import "image/color"
+
+// Spacer is an empty widget that takes up space in layouts.
+type Spacer struct {
+	BaseWidget
+
+	// Fixed size (0 = flexible)
+	fixedWidth  float32
+	fixedHeight float32
+}
+
+// NewSpacer creates a flexible spacer that expands to fill available space.
+func NewSpacer() *Spacer {
+	return &Spacer{
+		BaseWidget: NewBaseWidget(),
+	}
+}
+
+// FixedSpacer creates a spacer with fixed dimensions.
+func FixedSpacer(w, h float32) *Spacer {
+	return &Spacer{
+		BaseWidget:  NewBaseWidget(),
+		fixedWidth:  w,
+		fixedHeight: h,
+	}
+}
+
+func (s *Spacer) WithSize(w, h float32) *Spacer {
+	s.fixedWidth = w
+	s.fixedHeight = h
+	return s
+}
+
+func (s *Spacer) Layout(ctx *LayoutContext, constraints Constraints) Size {
+	w := s.fixedWidth
+	h := s.fixedHeight
+
+	if w == 0 {
+		w = constraints.MaxW
+	}
+	if h == 0 {
+		h = constraints.MaxH
+	}
+
+	w = clamp(w, constraints.MinW, constraints.MaxW)
+	h = clamp(h, constraints.MinH, constraints.MaxH)
+
+	return Size{W: w, H: h}
+}
+
+func (s *Spacer) Draw(ctx *DrawContext) {
+	// Spacers are invisible
+}
+
+func (s *Spacer) HandleEvent(ctx *EventContext, event Event) bool {
+	return false
+}
+
+// Box is a simple colored rectangle widget.
+type Box struct {
+	BaseWidget
+
+	color       color.Color
+	fixedWidth  float32
+	fixedHeight float32
+}
+
+// NewBox creates a colored box widget.
+func NewBox(c color.Color) *Box {
+	return &Box{
+		BaseWidget: NewBaseWidget(),
+		color:      c,
+	}
+}
+
+func (b *Box) WithSize(w, h float32) *Box {
+	b.fixedWidth = w
+	b.fixedHeight = h
+	return b
+}
+
+func (b *Box) WithColor(c color.Color) *Box {
+	b.color = c
+	return b
+}
+
+func (b *Box) Layout(ctx *LayoutContext, constraints Constraints) Size {
+	w := b.fixedWidth
+	h := b.fixedHeight
+
+	if w == 0 {
+		w = constraints.MaxW
+	}
+	if h == 0 {
+		h = constraints.MaxH
+	}
+
+	w = clamp(w, constraints.MinW, constraints.MaxW)
+	h = clamp(h, constraints.MinH, constraints.MaxH)
+
+	return Size{W: w, H: h}
+}
+
+func (b *Box) Draw(ctx *DrawContext) {
+	if !b.visible || b.color == nil {
+		return
+	}
+	bounds := b.Bounds()
+	ctx.Frame.RenderQuad(bounds.X, bounds.Y, bounds.W, bounds.H, nil, b.color)
+}
+
+func (b *Box) HandleEvent(ctx *EventContext, event Event) bool {
+	return false
+}
+
+// Padding wraps a widget with padding.
+type Padding struct {
+	BaseWidget
+
+	content Widget
+	padding EdgeInsets
+}
+
+// NewPadding creates a padding wrapper.
+func NewPadding(content Widget, padding EdgeInsets) *Padding {
+	return &Padding{
+		BaseWidget: NewBaseWidget(),
+		content:    content,
+		padding:    padding,
+	}
+}
+
+func (p *Padding) Layout(ctx *LayoutContext, constraints Constraints) Size {
+	contentConstraints := Constraints{
+		MinW: max(0, constraints.MinW-p.padding.Horizontal()),
+		MaxW: max(0, constraints.MaxW-p.padding.Horizontal()),
+		MinH: max(0, constraints.MinH-p.padding.Vertical()),
+		MaxH: max(0, constraints.MaxH-p.padding.Vertical()),
+	}
+
+	var contentSize Size
+	if p.content != nil {
+		contentSize = p.content.Layout(ctx, contentConstraints)
+	}
+
+	return Size{
+		W: contentSize.W + p.padding.Horizontal(),
+		H: contentSize.H + p.padding.Vertical(),
+	}
+}
+
+func (p *Padding) SetBounds(bounds Rect) {
+	p.BaseWidget.SetBounds(bounds)
+	if p.content != nil {
+		p.content.SetBounds(bounds.Inset(p.padding.Left, p.padding.Top, p.padding.Right, p.padding.Bottom))
+	}
+}
+
+func (p *Padding) Draw(ctx *DrawContext) {
+	if !p.visible {
+		return
+	}
+	if p.content != nil {
+		p.content.Draw(ctx)
+	}
+}
+
+func (p *Padding) HandleEvent(ctx *EventContext, event Event) bool {
+	if p.content != nil {
+		return p.content.HandleEvent(ctx, event)
+	}
+	return false
+}
+
+func (p *Padding) Children() []Widget {
+	if p.content != nil {
+		return []Widget{p.content}
+	}
+	return nil
+}
+
+// Center wraps a widget and centers it within available space.
+type Center struct {
+	BaseWidget
+
+	content Widget
+}
+
+// NewCenter creates a centering wrapper.
+func NewCenter(content Widget) *Center {
+	return &Center{
+		BaseWidget: NewBaseWidget(),
+		content:    content,
+	}
+}
+
+func (c *Center) Layout(ctx *LayoutContext, constraints Constraints) Size {
+	if c.content != nil {
+		c.content.Layout(ctx, Unconstrained())
+	}
+	return Size{W: constraints.MaxW, H: constraints.MaxH}
+}
+
+func (c *Center) SetBounds(bounds Rect) {
+	c.BaseWidget.SetBounds(bounds)
+	if c.content != nil {
+		contentBounds := c.content.Bounds()
+		x := bounds.X + (bounds.W-contentBounds.W)/2
+		y := bounds.Y + (bounds.H-contentBounds.H)/2
+		c.content.SetBounds(Rect{X: x, Y: y, W: contentBounds.W, H: contentBounds.H})
+	}
+}
+
+func (c *Center) Draw(ctx *DrawContext) {
+	if !c.visible {
+		return
+	}
+	if c.content != nil {
+		c.content.Draw(ctx)
+	}
+}
+
+func (c *Center) HandleEvent(ctx *EventContext, event Event) bool {
+	if c.content != nil {
+		return c.content.HandleEvent(ctx, event)
+	}
+	return false
+}
+
+func (c *Center) Children() []Widget {
+	if c.content != nil {
+		return []Widget{c.content}
+	}
+	return nil
+}
+
+// Positioned allows absolute positioning of a widget.
+type Positioned struct {
+	BaseWidget
+
+	content Widget
+	x, y    float32
+	w, h    float32
+}
+
+// NewPositioned creates an absolutely positioned widget.
+func NewPositioned(content Widget, x, y, w, h float32) *Positioned {
+	return &Positioned{
+		BaseWidget: NewBaseWidget(),
+		content:    content,
+		x:          x,
+		y:          y,
+		w:          w,
+		h:          h,
+	}
+}
+
+func (p *Positioned) Layout(ctx *LayoutContext, constraints Constraints) Size {
+	if p.content != nil {
+		p.content.Layout(ctx, Tight(p.w, p.h))
+	}
+	return Size{W: constraints.MaxW, H: constraints.MaxH}
+}
+
+func (p *Positioned) SetBounds(bounds Rect) {
+	p.BaseWidget.SetBounds(bounds)
+	if p.content != nil {
+		p.content.SetBounds(Rect{X: bounds.X + p.x, Y: bounds.Y + p.y, W: p.w, H: p.h})
+	}
+}
+
+func (p *Positioned) Draw(ctx *DrawContext) {
+	if !p.visible {
+		return
+	}
+	if p.content != nil {
+		p.content.Draw(ctx)
+	}
+}
+
+func (p *Positioned) HandleEvent(ctx *EventContext, event Event) bool {
+	if p.content != nil {
+		return p.content.HandleEvent(ctx, event)
+	}
+	return false
+}
+
+func (p *Positioned) Children() []Widget {
+	if p.content != nil {
+		return []Widget{p.content}
+	}
+	return nil
+}

--- a/internal/gowin/ui/spacer.go
+++ b/internal/gowin/ui/spacer.go
@@ -37,10 +37,15 @@ func (s *Spacer) Layout(ctx *LayoutContext, constraints Constraints) Size {
 	w := s.fixedWidth
 	h := s.fixedHeight
 
-	if w == 0 {
+	// Only expand to fill available space if constraints are bounded.
+	// Unbounded constraints (1e9) indicate the parent is measuring intrinsic size,
+	// so we should return 0 to not artificially inflate the layout.
+	const unboundedThreshold = 1e8
+
+	if w == 0 && constraints.MaxW < unboundedThreshold {
 		w = constraints.MaxW
 	}
-	if h == 0 {
+	if h == 0 && constraints.MaxH < unboundedThreshold {
 		h = constraints.MaxH
 	}
 
@@ -90,10 +95,13 @@ func (b *Box) Layout(ctx *LayoutContext, constraints Constraints) Size {
 	w := b.fixedWidth
 	h := b.fixedHeight
 
-	if w == 0 {
+	// Only expand to fill available space if constraints are bounded.
+	const unboundedThreshold = 1e8
+
+	if w == 0 && constraints.MaxW < unboundedThreshold {
 		w = constraints.MaxW
 	}
-	if h == 0 {
+	if h == 0 && constraints.MaxH < unboundedThreshold {
 		h = constraints.MaxH
 	}
 

--- a/internal/gowin/ui/stack.go
+++ b/internal/gowin/ui/stack.go
@@ -1,0 +1,177 @@
+package ui
+
+// Stack layers children on top of each other.
+// Children are drawn in order (first child at bottom, last at top).
+type Stack struct {
+	BaseWidget
+
+	children []Widget
+}
+
+// NewStack creates a new stack.
+func NewStack() *Stack {
+	return &Stack{
+		BaseWidget: NewBaseWidget(),
+	}
+}
+
+// AddChild adds a child to the stack.
+func (s *Stack) AddChild(child Widget) *Stack {
+	s.children = append(s.children, child)
+	return s
+}
+
+// AddChildren adds multiple children to the stack.
+func (s *Stack) AddChildren(children ...Widget) *Stack {
+	s.children = append(s.children, children...)
+	return s
+}
+
+func (s *Stack) ClearChildren() {
+	s.children = nil
+}
+
+func (s *Stack) Children() []Widget {
+	return s.children
+}
+
+func (s *Stack) Layout(ctx *LayoutContext, constraints Constraints) Size {
+	// Stack takes all available space
+	// Layout each child with the same constraints
+	for _, child := range s.children {
+		child.Layout(ctx, constraints)
+	}
+	return Size{W: constraints.MaxW, H: constraints.MaxH}
+}
+
+func (s *Stack) SetBounds(bounds Rect) {
+	s.BaseWidget.SetBounds(bounds)
+	// Each child gets the full bounds
+	for _, child := range s.children {
+		child.SetBounds(bounds)
+	}
+}
+
+func (s *Stack) Draw(ctx *DrawContext) {
+	if !s.visible {
+		return
+	}
+	// Draw children in order (first at bottom)
+	for _, child := range s.children {
+		child.Draw(ctx)
+	}
+}
+
+func (s *Stack) HandleEvent(ctx *EventContext, event Event) bool {
+	// Handle events in reverse order (top-most first)
+	for i := len(s.children) - 1; i >= 0; i-- {
+		if s.children[i].HandleEvent(ctx, event) {
+			return true
+		}
+	}
+	return false
+}
+
+// Align positions a child within the Stack bounds.
+type Align struct {
+	BaseWidget
+
+	content    Widget
+	horizontal float32 // 0 = left, 0.5 = center, 1 = right
+	vertical   float32 // 0 = top, 0.5 = center, 1 = bottom
+}
+
+// NewAlign creates an alignment wrapper.
+func NewAlign(content Widget, horizontal, vertical float32) *Align {
+	return &Align{
+		BaseWidget: NewBaseWidget(),
+		content:    content,
+		horizontal: horizontal,
+		vertical:   vertical,
+	}
+}
+
+// TopLeft aligns content to top-left.
+func TopLeft(content Widget) *Align {
+	return NewAlign(content, 0, 0)
+}
+
+// TopCenter aligns content to top-center.
+func TopCenter(content Widget) *Align {
+	return NewAlign(content, 0.5, 0)
+}
+
+// TopRight aligns content to top-right.
+func TopRight(content Widget) *Align {
+	return NewAlign(content, 1, 0)
+}
+
+// CenterLeft aligns content to center-left.
+func CenterLeft(content Widget) *Align {
+	return NewAlign(content, 0, 0.5)
+}
+
+// CenterCenter aligns content to center.
+func CenterCenter(content Widget) *Align {
+	return NewAlign(content, 0.5, 0.5)
+}
+
+// CenterRight aligns content to center-right.
+func CenterRight(content Widget) *Align {
+	return NewAlign(content, 1, 0.5)
+}
+
+// BottomLeft aligns content to bottom-left.
+func BottomLeft(content Widget) *Align {
+	return NewAlign(content, 0, 1)
+}
+
+// BottomCenter aligns content to bottom-center.
+func BottomCenter(content Widget) *Align {
+	return NewAlign(content, 0.5, 1)
+}
+
+// BottomRight aligns content to bottom-right.
+func BottomRight(content Widget) *Align {
+	return NewAlign(content, 1, 1)
+}
+
+func (a *Align) Layout(ctx *LayoutContext, constraints Constraints) Size {
+	if a.content != nil {
+		a.content.Layout(ctx, Unconstrained())
+	}
+	return Size{W: constraints.MaxW, H: constraints.MaxH}
+}
+
+func (a *Align) SetBounds(bounds Rect) {
+	a.BaseWidget.SetBounds(bounds)
+	if a.content != nil {
+		contentBounds := a.content.Bounds()
+		x := bounds.X + (bounds.W-contentBounds.W)*a.horizontal
+		y := bounds.Y + (bounds.H-contentBounds.H)*a.vertical
+		a.content.SetBounds(Rect{X: x, Y: y, W: contentBounds.W, H: contentBounds.H})
+	}
+}
+
+func (a *Align) Draw(ctx *DrawContext) {
+	if !a.visible {
+		return
+	}
+	if a.content != nil {
+		a.content.Draw(ctx)
+	}
+}
+
+func (a *Align) HandleEvent(ctx *EventContext, event Event) bool {
+	if a.content != nil {
+		return a.content.HandleEvent(ctx, event)
+	}
+	return false
+}
+
+func (a *Align) Children() []Widget {
+	if a.content != nil {
+		return []Widget{a.content}
+	}
+	return nil
+}

--- a/internal/gowin/ui/widget.go
+++ b/internal/gowin/ui/widget.go
@@ -1,0 +1,148 @@
+// Package ui provides a widget-based UI framework for graphics rendering.
+package ui
+
+import "image/color"
+
+// Rect represents a rectangle with position and size.
+type Rect struct {
+	X, Y float32
+	W, H float32
+}
+
+// Contains returns true if the point (px, py) is inside the rectangle.
+func (r Rect) Contains(px, py float32) bool {
+	return px >= r.X && px <= r.X+r.W && py >= r.Y && py <= r.Y+r.H
+}
+
+// Inset returns a new Rect inset by the given amounts.
+func (r Rect) Inset(left, top, right, bottom float32) Rect {
+	return Rect{
+		X: r.X + left,
+		Y: r.Y + top,
+		W: r.W - left - right,
+		H: r.H - top - bottom,
+	}
+}
+
+// Size represents dimensions.
+type Size struct {
+	W, H float32
+}
+
+// Constraints define min/max sizing constraints for layout.
+type Constraints struct {
+	MinW, MaxW float32
+	MinH, MaxH float32
+}
+
+// Unconstrained returns constraints with no limits.
+func Unconstrained() Constraints {
+	return Constraints{
+		MinW: 0, MaxW: 1e9,
+		MinH: 0, MaxH: 1e9,
+	}
+}
+
+// Tight returns constraints that force a specific size.
+func Tight(w, h float32) Constraints {
+	return Constraints{
+		MinW: w, MaxW: w,
+		MinH: h, MaxH: h,
+	}
+}
+
+// WidgetID is a unique identifier for a widget (for event targeting).
+type WidgetID uint64
+
+// Widget is the core interface for all UI elements.
+type Widget interface {
+	// ID returns a unique identifier for this widget.
+	ID() WidgetID
+
+	// Layout computes the desired size given constraints.
+	// Returns the actual size the widget wants.
+	Layout(ctx *LayoutContext, constraints Constraints) Size
+
+	// SetBounds sets the final position and size after layout.
+	SetBounds(bounds Rect)
+
+	// Bounds returns the current bounds.
+	Bounds() Rect
+
+	// Draw renders the widget to the frame.
+	Draw(ctx *DrawContext)
+
+	// HandleEvent processes an input event. Returns true if consumed.
+	HandleEvent(ctx *EventContext, event Event) bool
+
+	// Children returns child widgets (empty for leaf widgets).
+	Children() []Widget
+}
+
+// BaseWidget provides common functionality for all widgets.
+type BaseWidget struct {
+	id        WidgetID
+	bounds    Rect
+	visible   bool
+	enabled   bool
+	focusable bool
+}
+
+var nextWidgetID WidgetID = 1
+
+// NewBaseWidget creates a new BaseWidget with a unique ID.
+func NewBaseWidget() BaseWidget {
+	id := nextWidgetID
+	nextWidgetID++
+	return BaseWidget{
+		id:      id,
+		visible: true,
+		enabled: true,
+	}
+}
+
+func (w *BaseWidget) ID() WidgetID       { return w.id }
+func (w *BaseWidget) Bounds() Rect       { return w.bounds }
+func (w *BaseWidget) SetBounds(b Rect)   { w.bounds = b }
+func (w *BaseWidget) IsVisible() bool    { return w.visible }
+func (w *BaseWidget) SetVisible(v bool)  { w.visible = v }
+func (w *BaseWidget) IsEnabled() bool    { return w.enabled }
+func (w *BaseWidget) SetEnabled(e bool)  { w.enabled = e }
+func (w *BaseWidget) IsFocusable() bool  { return w.focusable }
+func (w *BaseWidget) Children() []Widget { return nil }
+
+// Helper functions
+func clamp(v, lo, hi float32) float32 {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+func max(a, b float32) float32 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func min(a, b float32) float32 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// ColorWithAlpha returns a color with modified alpha.
+func ColorWithAlpha(c color.Color, alpha uint8) color.Color {
+	r, g, b, _ := c.RGBA()
+	return color.RGBA{
+		R: uint8(r >> 8),
+		G: uint8(g >> 8),
+		B: uint8(b >> 8),
+		A: alpha,
+	}
+}


### PR DESCRIPTION
Introduces a custom UI layout framework with explicit widget types:

- Core framework (internal/gowin/ui/):
  - widget.go: Widget interface, BaseWidget, Rect, Size, Constraints
  - layout.go: Flexbox-style layout with Axis, alignment, EdgeInsets
  - context.go: LayoutContext, DrawContext, EventContext, Root
  - input.go: Event system (mouse, keyboard, scroll events)

- Widget implementations:
  - container.go: FlexContainer (Row/Column) with flex layout algorithm
  - label.go: Text display widget
  - button.go: Clickable button with hover/press states
  - card.go: Container with background, border styling
  - scrollview.go: Scrollable content area with scrollbars
  - image.go: Image, SVGImage, AnimatedLogo widgets
  - spacer.go: Spacer, Box, Padding, Center, Positioned helpers
  - stack.go: Stack for layered rendering, Align for positioning

- Screen implementations (cmd/ccapp/ui_screens.go):
  - LauncherScreen: Bundle carousel with cards
  - LoadingScreen: Spinning logo animation
  - ErrorScreen: Error message with buttons
  - TerminalScreen: Top bar for terminal mode

- Refactored main.go to use widget-based screens

The framework provides:
- Declarative UI construction with builder patterns
- Automatic layout calculation via flexbox model
- Event propagation through widget tree
- Clean separation of layout, drawing, and input handling