### PR TITLE
Perf Pass on macOS arm64

### DIFF
--- a/cmd/ccapp/main.go
+++ b/cmd/ccapp/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/tinyrange/cc/internal/assets"
 	"github.com/tinyrange/cc/internal/bundle"
+	"github.com/tinyrange/cc/internal/debug"
 	"github.com/tinyrange/cc/internal/devices/virtio"
 	"github.com/tinyrange/cc/internal/gowin/graphics"
 	"github.com/tinyrange/cc/internal/gowin/text"
@@ -77,6 +78,9 @@ type bootPrep struct {
 
 	// QEMU emulation config (for cross-architecture images)
 	qemuConfig *initx.QEMUEmulationConfig
+
+	// Snapshot caching config
+	useCommandLoop bool // If true, use CommandLoop mode for snapshot caching
 
 	// resources created during prep (must be cleaned up on error)
 	containerFS  *oci.ContainerFS
@@ -206,6 +210,9 @@ type Application struct {
 	// Shutdown state
 	shutdownRequested bool
 	shutdownCode      int
+
+	// Snapshot cache for fast VM startup
+	snapshotCache *initx.SnapshotCache
 }
 
 type rect struct {
@@ -504,6 +511,15 @@ func getBundlesDir() string {
 	return filepath.Join(configDir, "ccapp", "bundles")
 }
 
+// getSnapshotCacheDir returns the path to the snapshot cache directory.
+func getSnapshotCacheDir() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(configDir, "ccapp", "snapshots"), nil
+}
+
 func (app *Application) Run() error {
 	var err error
 
@@ -604,6 +620,21 @@ func (app *Application) Run() error {
 					settingsStore.ClearCleanupPending() // This resets retry count
 				}
 			}
+		}
+	}
+
+	// Initialize snapshot cache for fast VM startup (if enabled in settings)
+	if app.settings != nil && app.settings.Get().SnapshotCacheEnabled {
+		if snapshotIO := initx.GetSnapshotIO(); snapshotIO != nil {
+			cacheDir, err := getSnapshotCacheDir()
+			if err != nil {
+				slog.Warn("failed to get snapshot cache directory", "error", err)
+			} else {
+				app.snapshotCache = initx.NewSnapshotCache(cacheDir, snapshotIO)
+				slog.Info("snapshot cache initialized", "cache_dir", cacheDir)
+			}
+		} else {
+			slog.Debug("snapshot caching not available on this platform")
 		}
 	}
 
@@ -1271,20 +1302,23 @@ func (app *Application) startBootBundle(index int) {
 	preOpenedHV := app.hypervisor
 	app.hypervisor = nil
 
+	// Check if snapshot caching is enabled
+	useCommandLoop := app.snapshotCache != nil
+
 	// Background prep: do anything slow/off-GPU here (disk IO, kernel fetch, etc).
-	go func(b discoveredBundle, arch hv.CpuArchitecture, hvArg hv.Hypervisor, out chan<- bootResult) {
-		prep, err := prepareBootBundle(b, arch, hvArg)
+	go func(b discoveredBundle, arch hv.CpuArchitecture, hvArg hv.Hypervisor, cmdLoop bool, out chan<- bootResult) {
+		prep, err := prepareBootBundle(b, arch, hvArg, cmdLoop)
 		out <- bootResult{prep: prep, err: err}
-	}(b, hvArch, preOpenedHV, ch)
+	}(b, hvArch, preOpenedHV, useCommandLoop, ch)
 }
 
-func prepareBootBundle(b discoveredBundle, hvArch hv.CpuArchitecture, preOpenedHV hv.Hypervisor) (_ *bootPrep, retErr error) {
+func prepareBootBundle(b discoveredBundle, hvArch hv.CpuArchitecture, preOpenedHV hv.Hypervisor, useCommandLoop bool) (_ *bootPrep, retErr error) {
 	if b.Dir == "" {
 		return nil, fmt.Errorf("invalid bundle: empty dir")
 	}
-	slog.Info("boot bundle prep started", "bundle_dir", b.Dir, "bundle_name", b.Meta.Name, "arch", hvArch)
+	slog.Info("boot bundle prep started", "bundle_dir", b.Dir, "bundle_name", b.Meta.Name, "arch", hvArch, "command_loop", useCommandLoop)
 
-	prep := &bootPrep{hvArch: hvArch}
+	prep := &bootPrep{hvArch: hvArch, useCommandLoop: useCommandLoop}
 	defer func() {
 		if retErr != nil {
 			// Best-effort cleanup on failure.
@@ -1504,21 +1538,55 @@ func (app *Application) finalizeBoot(prep *bootPrep) (retErr error) {
 		opts = append(opts, initx.WithQEMUEmulationEnabled(true))
 	}
 
+	// Snapshot caching setup
+	var sessionCfg initx.SessionConfig
+	var configHash hv.VMConfigHash
+
+	if prep.useCommandLoop && app.snapshotCache != nil {
+		// Compute config hash based on VM configuration
+		configHash = hv.ComputeConfigHash(
+			prep.hvArch,
+			prep.memoryMB<<20, // Convert MB to bytes
+			0,                 // Memory base will be set by VM creation
+			prep.cpus,
+			nil, // Device configs - simplified for now
+		)
+
+		// Use a very old time as reference - snapshots are valid unless explicitly invalidated
+		var referenceTime time.Time
+
+		if app.snapshotCache.HasValidSnapshot(configHash, referenceTime) {
+			// Try to load cached snapshot
+			snap, loadErr := app.snapshotCache.LoadSnapshot(configHash)
+			if loadErr == nil {
+				debug.Writef("ccapp.finalizeBoot snapshot", "using cached snapshot")
+				opts = append(opts, initx.WithSnapshot(snap))
+				sessionCfg.SkipBoot = true
+			} else {
+				slog.Debug("Failed to load snapshot, falling back to boot", "error", loadErr)
+			}
+		}
+	}
+
 	vm, err := initx.NewVirtualMachine(prep.hypervisor, prep.cpus, prep.memoryMB, prep.kernelLoader, opts...)
 	if err != nil {
 		termView.Close()
 		return fmt.Errorf("create VM: %w", err)
 	}
 
-	// Build init program with network always enabled.
+	// Build init program - use CommandLoop mode if snapshot caching is enabled
 	prog, err := initx.BuildContainerInitProgram(initx.ContainerInitConfig{
-		Arch:          prep.hvArch,
-		Cmd:           prep.execCmd,
-		Env:           prep.env,
-		WorkDir:       prep.workDir,
-		EnableNetwork: true,
-		Exec:          prep.exec,
-		QEMUEmulation: prep.qemuConfig,
+		Arch:                  prep.hvArch,
+		Cmd:                   prep.execCmd, // Used when CommandLoop is false
+		Env:                   prep.env,
+		WorkDir:               prep.workDir,
+		EnableNetwork:         true,
+		Exec:                  prep.exec,
+		CommandLoop:           prep.useCommandLoop,
+		QEMUEmulation:         prep.qemuConfig,
+		MailboxPhysAddr:       vm.MailboxPhysAddr(),
+		TimesliceMMIOPhysAddr: vm.TimesliceMMIOPhysAddr(),
+		ConfigRegionPhysAddr:  vm.ConfigRegionPhysAddr(),
 	})
 	if err != nil {
 		vm.Close()
@@ -1526,8 +1594,48 @@ func (app *Application) finalizeBoot(prep *bootPrep) (retErr error) {
 		return err
 	}
 
-	session := initx.StartSession(context.Background(), vm, prog, initx.SessionConfig{})
-	slog.Info("VM session started")
+	// Handle snapshot caching for CommandLoop mode
+	if prep.useCommandLoop && app.snapshotCache != nil {
+		if sessionCfg.SkipBoot {
+			// Restored from snapshot - write the command to execute
+			if writeErr := vm.WriteExecCommand(prep.execCmd[0], prep.execCmd, prep.env); writeErr != nil {
+				slog.Debug("Failed to write exec command after restore", "error", writeErr)
+				vm.Close()
+				termView.Close()
+				return fmt.Errorf("write exec command: %w", writeErr)
+			}
+			debug.Writef("ccapp.finalizeBoot snapshot", "command written after restore")
+		} else {
+			// Set up callback to capture snapshot after boot completes
+			sessionCfg.OnBootComplete = func() error {
+				// Clear any stale command before capturing snapshot
+				if clearErr := vm.ClearExecCommand(); clearErr != nil {
+					slog.Debug("Failed to clear exec command before snapshot", "error", clearErr)
+				}
+
+				snap, captureErr := vm.CaptureSnapshot()
+				if captureErr != nil {
+					slog.Debug("Failed to capture boot snapshot", "error", captureErr)
+					return nil // Don't fail the session
+				}
+				if saveErr := app.snapshotCache.SaveSnapshot(configHash, snap); saveErr != nil {
+					slog.Debug("Failed to save boot snapshot", "error", saveErr)
+				} else {
+					debug.Writef("ccapp.finalizeBoot snapshot", "saved to cache")
+				}
+
+				// Write the command for the guest to execute
+				if writeErr := vm.WriteExecCommand(prep.execCmd[0], prep.execCmd, prep.env); writeErr != nil {
+					return fmt.Errorf("write exec command: %w", writeErr)
+				}
+
+				return nil
+			}
+		}
+	}
+
+	session := initx.StartSession(context.Background(), vm, prog, sessionCfg)
+	slog.Info("VM session started", "command_loop", prep.useCommandLoop, "skip_boot", sessionCfg.SkipBoot)
 
 	app.running = &runningVM{
 		vm:          vm,
@@ -1613,6 +1721,9 @@ func (app *Application) startCustomVM(sourceType VMSourceType, sourcePath string
 	preOpenedHV := app.hypervisor
 	app.hypervisor = nil
 
+	// Check if snapshot caching is enabled
+	useCommandLoop := app.snapshotCache != nil
+
 	// Create progress callback for image downloads
 	progressCallback := func(progress oci.DownloadProgress) {
 		app.bootProgressMu.Lock()
@@ -1620,7 +1731,7 @@ func (app *Application) startCustomVM(sourceType VMSourceType, sourcePath string
 		app.bootProgressMu.Unlock()
 	}
 
-	go func(srcType VMSourceType, srcPath string, arch hv.CpuArchitecture, hvArg hv.Hypervisor, out chan<- bootResult, progressCb oci.ProgressCallback) {
+	go func(srcType VMSourceType, srcPath string, arch hv.CpuArchitecture, hvArg hv.Hypervisor, cmdLoop bool, out chan<- bootResult, progressCb oci.ProgressCallback) {
 		var prep *bootPrep
 		var err error
 
@@ -1632,20 +1743,20 @@ func (app *Application) startCustomVM(sourceType VMSourceType, sourcePath string
 				out <- bootResult{err: metaErr}
 				return
 			}
-			prep, err = prepareBootBundle(discoveredBundle{Dir: srcPath, Meta: meta}, arch, hvArg)
+			prep, err = prepareBootBundle(discoveredBundle{Dir: srcPath, Meta: meta}, arch, hvArg, cmdLoop)
 
 		case VMSourceTarball:
-			prep, err = prepareFromTarball(srcPath, arch, hvArg)
+			prep, err = prepareFromTarball(srcPath, arch, hvArg, cmdLoop)
 
 		case VMSourceImageName:
-			prep, err = prepareFromImageName(srcPath, arch, hvArg, progressCb)
+			prep, err = prepareFromImageName(srcPath, arch, hvArg, cmdLoop, progressCb)
 
 		default:
 			err = fmt.Errorf("unknown source type: %s", srcType)
 		}
 
 		out <- bootResult{prep: prep, err: err}
-	}(sourceType, sourcePath, hvArch, preOpenedHV, ch, progressCallback)
+	}(sourceType, sourcePath, hvArch, preOpenedHV, useCommandLoop, ch, progressCallback)
 }
 
 // installBundle installs a VM source as a bundle in the bundles directory.
@@ -1757,8 +1868,8 @@ func installImageAsBundle(img *oci.Image, bundlePath, name, source string) error
 }
 
 // prepareFromTarball loads a VM from an OCI tarball
-func prepareFromTarball(tarPath string, hvArch hv.CpuArchitecture, preOpenedHV hv.Hypervisor) (*bootPrep, error) {
-	slog.Info("loading VM from tarball", "path", tarPath, "arch", hvArch)
+func prepareFromTarball(tarPath string, hvArch hv.CpuArchitecture, preOpenedHV hv.Hypervisor, useCommandLoop bool) (*bootPrep, error) {
+	slog.Info("loading VM from tarball", "path", tarPath, "arch", hvArch, "command_loop", useCommandLoop)
 
 	client, err := oci.NewClient("")
 	if err != nil {
@@ -1770,12 +1881,12 @@ func prepareFromTarball(tarPath string, hvArch hv.CpuArchitecture, preOpenedHV h
 		return nil, fmt.Errorf("load tarball: %w", err)
 	}
 
-	return prepareFromImage(img, hvArch, preOpenedHV)
+	return prepareFromImage(img, hvArch, preOpenedHV, useCommandLoop)
 }
 
 // prepareFromImageName pulls a container image and prepares it for boot
-func prepareFromImageName(imageName string, hvArch hv.CpuArchitecture, preOpenedHV hv.Hypervisor, progressCallback oci.ProgressCallback) (*bootPrep, error) {
-	slog.Info("pulling container image", "image", imageName, "arch", hvArch)
+func prepareFromImageName(imageName string, hvArch hv.CpuArchitecture, preOpenedHV hv.Hypervisor, useCommandLoop bool, progressCallback oci.ProgressCallback) (*bootPrep, error) {
+	slog.Info("pulling container image", "image", imageName, "arch", hvArch, "command_loop", useCommandLoop)
 
 	client, err := oci.NewClient("")
 	if err != nil {
@@ -1792,12 +1903,12 @@ func prepareFromImageName(imageName string, hvArch hv.CpuArchitecture, preOpened
 		return nil, fmt.Errorf("pull image: %w", err)
 	}
 
-	return prepareFromImage(img, hvArch, preOpenedHV)
+	return prepareFromImage(img, hvArch, preOpenedHV, useCommandLoop)
 }
 
 // prepareFromImage prepares a VM from an already-loaded OCI image
-func prepareFromImage(img *oci.Image, hvArch hv.CpuArchitecture, preOpenedHV hv.Hypervisor) (_ *bootPrep, retErr error) {
-	prep := &bootPrep{hvArch: hvArch}
+func prepareFromImage(img *oci.Image, hvArch hv.CpuArchitecture, preOpenedHV hv.Hypervisor, useCommandLoop bool) (_ *bootPrep, retErr error) {
+	prep := &bootPrep{hvArch: hvArch, useCommandLoop: useCommandLoop}
 	defer func() {
 		if retErr != nil {
 			if prep.hypervisor != nil {

--- a/cmd/ccapp/settings.go
+++ b/cmd/ccapp/settings.go
@@ -17,6 +17,7 @@ type AppSettings struct {
 	CleanupPending        string    `json:"cleanup_pending,omitempty"`    // Path to delete on next startup
 	CleanupRetryCount     int       `json:"cleanup_retry_count,omitempty"` // Number of cleanup retry attempts
 	CreateDesktopShortcut bool      `json:"create_desktop_shortcut"`      // Create desktop/start menu shortcut (Windows/Linux)
+	SnapshotCacheEnabled  bool      `json:"snapshot_cache_enabled"`       // Enable VM boot snapshot caching (default: false)
 }
 
 // SettingsStore manages persistent storage of application settings
@@ -117,5 +118,11 @@ func (s *SettingsStore) IncrementCleanupRetryCount() (int, error) {
 func (s *SettingsStore) ClearCleanupPending() error {
 	s.settings.CleanupPending = ""
 	s.settings.CleanupRetryCount = 0
+	return s.save()
+}
+
+// SetSnapshotCacheEnabled sets the snapshot cache preference
+func (s *SettingsStore) SetSnapshotCacheEnabled(enabled bool) error {
+	s.settings.SnapshotCacheEnabled = enabled
 	return s.save()
 }

--- a/cmd/timeslice/main.go
+++ b/cmd/timeslice/main.go
@@ -19,8 +19,8 @@ type timesliceRecord struct {
 }
 
 func (r *timesliceRecord) String() string {
-	return fmt.Sprintf("% 40s flags=% 10s count=% 8d sum=% 16s min=% 16s max=% 16s avg=% 16s",
-		r.ID, r.Flags, r.Count,
+	return fmt.Sprintf("% 40s count=% 8d sum=% 16s min=% 16s max=% 16s avg=% 16s",
+		r.ID, r.Count,
 		r.Sum,
 		r.Min,
 		r.Max,

--- a/internal/acpi/install_test.go
+++ b/internal/acpi/install_test.go
@@ -211,6 +211,18 @@ func (f *fakeVM) AddDevice(hv.Device) error {
 	return fmt.Errorf("not implemented")
 }
 
-func (f *fakeVM) AddDeviceFromTemplate(hv.DeviceTemplate) error {
+func (f *fakeVM) AddDeviceFromTemplate(hv.DeviceTemplate) (hv.Device, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeVM) AllocateMMIO(req hv.MMIOAllocationRequest) (hv.MMIOAllocation, error) {
+	return hv.MMIOAllocation{}, fmt.Errorf("not implemented")
+}
+
+func (f *fakeVM) RegisterFixedMMIO(name string, base, size uint64) error {
 	return fmt.Errorf("not implemented")
+}
+
+func (f *fakeVM) GetAllocatedMMIORegions() []hv.MMIOAllocation {
+	return nil
 }

--- a/internal/cmd/benchmark/main.go
+++ b/internal/cmd/benchmark/main.go
@@ -56,6 +56,7 @@ var (
 	tsCaptureSnapshot           = timeslice.RegisterKind("benchmark::capture_snapshot", 0)
 	tsRestoreSnapshot           = timeslice.RegisterKind("benchmark::restore_snapshot", 0)
 	tsOverallTime               = timeslice.RegisterKind("benchmark::overall", 0)
+	tsWriteCommand              = timeslice.RegisterKind("benchmark::write_command", 0)
 )
 
 func (b *benchmark) runCommand(
@@ -256,7 +257,6 @@ func (b *benchmark) run() error {
 	bundleDir := fs.String("bundleDir", "", "the directory to load bundles from")
 	bundleName := fs.String("bundle", "alpine", "the oci image name to run inside the virtual machine")
 	testCommand := fs.String("cmd", "/usr/bin/whoami", "the command to execute inside the virtual machine")
-
 	tsFile := fs.String("tsfile", "", "record a timeslice file for later analysis")
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
@@ -286,6 +286,7 @@ func (b *benchmark) run() error {
 		*bundleDir = filepath.Join(userDir, "ccapp", "bundles")
 	}
 
+	// Original mode: create new VM for each iteration
 	start := time.Now()
 
 	// execute a first boot to check and capture the snapshot.

--- a/internal/cmd/benchmark/main.go
+++ b/internal/cmd/benchmark/main.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/schollz/progressbar/v3"
+	"github.com/tinyrange/cc/internal/bundle"
+	"github.com/tinyrange/cc/internal/devices/virtio"
+	"github.com/tinyrange/cc/internal/hv"
+	"github.com/tinyrange/cc/internal/hv/factory"
+	"github.com/tinyrange/cc/internal/initx"
+	"github.com/tinyrange/cc/internal/linux/kernel"
+	"github.com/tinyrange/cc/internal/oci"
+	"github.com/tinyrange/cc/internal/vfs"
+)
+
+func parseArchitecture(arch string) (hv.CpuArchitecture, error) {
+	switch arch {
+	case "amd64", "x86_64":
+		return hv.ArchitectureX86_64, nil
+	case "arm64", "aarch64":
+		return hv.ArchitectureARM64, nil
+	default:
+		return "", fmt.Errorf("unsupported architecture: %s", arch)
+	}
+}
+
+type benchmark struct {
+}
+
+func (b *benchmark) runCommand(bundleDir string, bundleName string, command string) error {
+	bundlePath := filepath.Join(bundleDir, bundleName)
+
+	meta, err := bundle.LoadMetadata(bundlePath)
+	if err != nil {
+		return fmt.Errorf("")
+	}
+
+	// Determine image directory
+	imageDir := filepath.Join(bundlePath, meta.Boot.ImageDir)
+	if meta.Boot.ImageDir == "" {
+		imageDir = filepath.Join(bundlePath, "image")
+	}
+
+	// Determine architecture early so we can validate the image
+	hvArch, err := parseArchitecture(runtime.GOARCH)
+	if err != nil {
+		return fmt.Errorf("determine architecture: %w", err)
+	}
+
+	// Load OCI image with architecture validation
+	img, err := oci.LoadFromDirForArch(imageDir, hvArch)
+	if err != nil {
+		return fmt.Errorf("load image: %w", err)
+	}
+
+	containerFS, err := oci.NewContainerFS(img)
+	if err != nil {
+		return fmt.Errorf("create container filesystem: %w", err)
+	}
+	defer containerFS.Close()
+
+	commandArgs := []string{"/bin/sh", "-c", command}
+
+	fsBackend := vfs.NewVirtioFsBackendWithAbstract()
+	if err := fsBackend.SetAbstractRoot(containerFS); err != nil {
+		return fmt.Errorf("set container filesystem as root: %w", err)
+	}
+
+	h, err := factory.OpenWithArchitecture(hvArch)
+	if err != nil {
+		return fmt.Errorf("create hypervisor: %w", err)
+	}
+	defer h.Close()
+
+	kernelLoader, err := kernel.LoadForArchitecture(hvArch)
+	if err != nil {
+		return fmt.Errorf("load kernel: %w", err)
+	}
+
+	buf := new(bytes.Buffer)
+
+	opts := []initx.Option{
+		initx.WithDeviceTemplate(virtio.FSTemplate{
+			Tag:     "rootfs",
+			Backend: fsBackend,
+			Arch:    hvArch,
+		}),
+		initx.WithConsoleOutput(buf),
+	}
+
+	vm, err := initx.NewVirtualMachine(h, 1, 1024, kernelLoader, opts...)
+	if err != nil {
+		return fmt.Errorf("create VM: %w", err)
+	}
+	defer vm.Close()
+
+	// Build init program
+	prog, err := initx.BuildContainerInitProgram(initx.ContainerInitConfig{
+		Arch:    hvArch,
+		Cmd:     commandArgs,
+		Env:     img.Config.Env,
+		WorkDir: img.Config.WorkingDir,
+		Exec:    meta.Boot.Exec,
+		UID:     img.Config.UID,
+		GID:     img.Config.GID,
+	})
+	if err != nil {
+		return fmt.Errorf("build init program: %w", err)
+	}
+
+	session := initx.StartSession(context.Background(), vm, prog, initx.SessionConfig{})
+
+	return session.Wait()
+}
+
+func (b *benchmark) run() error {
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	n := fs.Int("n", 10, "the number of VM runs to execute")
+	bundleDir := fs.String("bundleDir", "", "the directory to load bundles from")
+	bundleName := fs.String("bundle", "alpine", "the oci image name to run inside the virtual machine")
+	testCommand := fs.String("cmd", "whoami", "the command to execute inside the virtual machine")
+
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		return fmt.Errorf("failed to parse args: %w", err)
+	}
+
+	if *bundleDir == "" {
+		userDir, err := os.UserConfigDir()
+		if err != nil {
+			return fmt.Errorf("failed to get user config dir: %w", err)
+		}
+
+		*bundleDir = filepath.Join(userDir, "ccapp", "bundles")
+	}
+
+	pb := progressbar.Default(int64(*n))
+	defer pb.Close()
+
+	for range *n {
+		if err := b.runCommand(*bundleDir, *bundleName, *testCommand); err != nil {
+			return fmt.Errorf("failed to run command: %w", err)
+		}
+
+		pb.Add(1)
+	}
+
+	return nil
+}
+
+func main() {
+	b := benchmark{}
+
+	if err := b.run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to run benchmark: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/internal/cmd/benchmark/main.go
+++ b/internal/cmd/benchmark/main.go
@@ -115,12 +115,17 @@ func (b *benchmark) runCommand(
 
 	tsRecord.Record(tsFactoryOpen)
 
-	kernelLoader, err := kernel.LoadForArchitecture(hvArch)
-	if err != nil {
-		return fmt.Errorf("load kernel: %w", err)
+	// Only load kernel when no snapshot exists (first boot)
+	// When restoring from snapshot, the kernel is already in guest memory
+	var kernelLoader kernel.Kernel
+	if b.snapshot == nil {
+		var err error
+		kernelLoader, err = kernel.LoadForArchitecture(hvArch)
+		if err != nil {
+			return fmt.Errorf("load kernel: %w", err)
+		}
+		tsRecord.Record(tsKernelLoad)
 	}
-
-	tsRecord.Record(tsKernelLoad)
 
 	buf := new(bytes.Buffer)
 

--- a/internal/cmd/codesign/codesign.go
+++ b/internal/cmd/codesign/codesign.go
@@ -20,7 +20,6 @@ import (
 	"hash"
 	"io"
 	"log"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -723,10 +722,7 @@ func main() {
 		}
 	}
 
-	slog.Info("code signing completed",
-		"path", *binPath,
-		"entitlements", *entPath,
-	)
+	fmt.Fprintf(os.Stderr, "code signing complete path=%s entitlements=%s\n", *binPath, *entPath)
 }
 
 func textSegmentInfo(f *macho.File) (int64, int64, error) {

--- a/internal/devices/virtio/console_test.go
+++ b/internal/devices/virtio/console_test.go
@@ -71,14 +71,19 @@ func (vm *consoleTestVM) VirtualCPUCall(id int, f func(vcpu hv.VirtualCPU) error
 	return nil
 }
 func (vm *consoleTestVM) AddDevice(dev hv.Device) error { return nil }
-func (vm *consoleTestVM) AddDeviceFromTemplate(template hv.DeviceTemplate) error {
-	return nil
+func (vm *consoleTestVM) AddDeviceFromTemplate(template hv.DeviceTemplate) (hv.Device, error) {
+	return nil, nil
 }
 func (vm *consoleTestVM) AllocateMemory(physAddr, size uint64) (hv.MemoryRegion, error) {
 	return nil, fmt.Errorf("not implemented")
 }
-func (vm *consoleTestVM) CaptureSnapshot() (hv.Snapshot, error)         { return nil, nil }
-func (vm *consoleTestVM) RestoreSnapshot(snap hv.Snapshot) error        { return nil }
+func (vm *consoleTestVM) CaptureSnapshot() (hv.Snapshot, error)  { return nil, nil }
+func (vm *consoleTestVM) RestoreSnapshot(snap hv.Snapshot) error { return nil }
+func (vm *consoleTestVM) AllocateMMIO(req hv.MMIOAllocationRequest) (hv.MMIOAllocation, error) {
+	return hv.MMIOAllocation{}, nil
+}
+func (vm *consoleTestVM) RegisterFixedMMIO(name string, base, size uint64) error { return nil }
+func (vm *consoleTestVM) GetAllocatedMMIORegions() []hv.MMIOAllocation           { return nil }
 
 var _ hv.VirtualMachine = (*consoleTestVM)(nil)
 

--- a/internal/devices/virtio/device_base.go
+++ b/internal/devices/virtio/device_base.go
@@ -224,6 +224,21 @@ func (b *MMIODeviceBase) IRQLine() uint32 {
 	return b.irqLine
 }
 
+// AllocatedMMIOBase implements AllocatedVirtioMMIODevice.
+func (b *MMIODeviceBase) AllocatedMMIOBase() uint64 {
+	return b.base
+}
+
+// AllocatedMMIOSize implements AllocatedVirtioMMIODevice.
+func (b *MMIODeviceBase) AllocatedMMIOSize() uint64 {
+	return b.size
+}
+
+// AllocatedIRQLine implements AllocatedVirtioMMIODevice.
+func (b *MMIODeviceBase) AllocatedIRQLine() uint32 {
+	return b.irqLine
+}
+
 // NewMMIODeviceBase creates a new MMIODeviceBase with the given configuration.
 func NewMMIODeviceBase(base, size uint64, irqLine uint32, config *MMIODeviceConfig) MMIODeviceBase {
 	return MMIODeviceBase{

--- a/internal/devices/virtio/fs_bench_test.go
+++ b/internal/devices/virtio/fs_bench_test.go
@@ -74,12 +74,19 @@ func (vm *fsTestVM) MemoryBase() uint64                                        {
 func (vm *fsTestVM) Run(ctx context.Context, cfg hv.RunConfig) error           { return nil }
 func (vm *fsTestVM) VirtualCPUCall(id int, f func(vcpu hv.VirtualCPU) error) error { return nil }
 func (vm *fsTestVM) AddDevice(dev hv.Device) error                             { return nil }
-func (vm *fsTestVM) AddDeviceFromTemplate(template hv.DeviceTemplate) error    { return nil }
+func (vm *fsTestVM) AddDeviceFromTemplate(template hv.DeviceTemplate) (hv.Device, error) {
+	return nil, nil
+}
 func (vm *fsTestVM) AllocateMemory(physAddr, size uint64) (hv.MemoryRegion, error) {
 	return nil, fmt.Errorf("not implemented")
 }
-func (vm *fsTestVM) CaptureSnapshot() (hv.Snapshot, error) { return nil, nil }
+func (vm *fsTestVM) CaptureSnapshot() (hv.Snapshot, error)  { return nil, nil }
 func (vm *fsTestVM) RestoreSnapshot(snap hv.Snapshot) error { return nil }
+func (vm *fsTestVM) AllocateMMIO(req hv.MMIOAllocationRequest) (hv.MMIOAllocation, error) {
+	return hv.MMIOAllocation{}, nil
+}
+func (vm *fsTestVM) RegisterFixedMMIO(name string, base, size uint64) error { return nil }
+func (vm *fsTestVM) GetAllocatedMMIORegions() []hv.MMIOAllocation           { return nil }
 
 var _ hv.VirtualMachine = (*fsTestVM)(nil)
 

--- a/internal/devices/virtio/net_bench_test.go
+++ b/internal/devices/virtio/net_bench_test.go
@@ -74,12 +74,19 @@ func (vm *netTestVM) MemoryBase() uint64                                        
 func (vm *netTestVM) Run(ctx context.Context, cfg hv.RunConfig) error           { return nil }
 func (vm *netTestVM) VirtualCPUCall(id int, f func(vcpu hv.VirtualCPU) error) error { return nil }
 func (vm *netTestVM) AddDevice(dev hv.Device) error                             { return nil }
-func (vm *netTestVM) AddDeviceFromTemplate(template hv.DeviceTemplate) error    { return nil }
+func (vm *netTestVM) AddDeviceFromTemplate(template hv.DeviceTemplate) (hv.Device, error) {
+	return nil, nil
+}
 func (vm *netTestVM) AllocateMemory(physAddr, size uint64) (hv.MemoryRegion, error) {
 	return nil, fmt.Errorf("not implemented")
 }
-func (vm *netTestVM) CaptureSnapshot() (hv.Snapshot, error) { return nil, nil }
+func (vm *netTestVM) CaptureSnapshot() (hv.Snapshot, error)  { return nil, nil }
 func (vm *netTestVM) RestoreSnapshot(snap hv.Snapshot) error { return nil }
+func (vm *netTestVM) AllocateMMIO(req hv.MMIOAllocationRequest) (hv.MMIOAllocation, error) {
+	return hv.MMIOAllocation{}, nil
+}
+func (vm *netTestVM) RegisterFixedMMIO(name string, base, size uint64) error { return nil }
+func (vm *netTestVM) GetAllocatedMMIORegions() []hv.MMIOAllocation           { return nil }
 
 var _ hv.VirtualMachine = (*netTestVM)(nil)
 

--- a/internal/devices/virtio/net_test.go
+++ b/internal/devices/virtio/net_test.go
@@ -99,8 +99,8 @@ func (m *mockVM) AddDevice(dev hv.Device) error {
 	return nil
 }
 
-func (m *mockVM) AddDeviceFromTemplate(template hv.DeviceTemplate) error {
-	return nil
+func (m *mockVM) AddDeviceFromTemplate(template hv.DeviceTemplate) (hv.Device, error) {
+	return nil, nil
 }
 
 func (m *mockVM) AllocateMemory(physAddr, size uint64) (hv.MemoryRegion, error) {
@@ -112,6 +112,18 @@ func (m *mockVM) CaptureSnapshot() (hv.Snapshot, error) {
 }
 
 func (m *mockVM) RestoreSnapshot(snap hv.Snapshot) error {
+	return nil
+}
+
+func (m *mockVM) AllocateMMIO(req hv.MMIOAllocationRequest) (hv.MMIOAllocation, error) {
+	return hv.MMIOAllocation{}, nil
+}
+
+func (m *mockVM) RegisterFixedMMIO(name string, base, size uint64) error {
+	return nil
+}
+
+func (m *mockVM) GetAllocatedMMIORegions() []hv.MMIOAllocation {
 	return nil
 }
 

--- a/internal/hv/address_space.go
+++ b/internal/hv/address_space.go
@@ -1,0 +1,153 @@
+package hv
+
+import (
+	"fmt"
+	"sync"
+)
+
+// AddressSpace manages physical address allocation for a VM.
+// It tracks RAM regions and allocates MMIO regions above RAM to avoid conflicts.
+type AddressSpace struct {
+	mu sync.Mutex
+
+	arch    CpuArchitecture
+	ramBase uint64
+	ramSize uint64
+
+	// nextMMIO is the next available address for MMIO allocation (above RAM)
+	nextMMIO uint64
+
+	// allocations holds all dynamically allocated MMIO regions
+	allocations []MMIOAllocation
+
+	// fixedRegions holds pre-determined MMIO regions (GIC, UART, HPET, etc.)
+	fixedRegions []MMIOAllocation
+}
+
+// NewAddressSpace creates a new physical address allocator for a VM.
+// MMIO allocations will start above ramBase+ramSize.
+func NewAddressSpace(arch CpuArchitecture, ramBase, ramSize uint64) *AddressSpace {
+	a := &AddressSpace{
+		arch:    arch,
+		ramBase: ramBase,
+		ramSize: ramSize,
+	}
+	// Start MMIO allocation above RAM, aligned to 4KB
+	a.nextMMIO = alignUp(ramBase+ramSize, 0x1000)
+	return a
+}
+
+// Allocate allocates an MMIO region with the specified requirements.
+// The region is placed above RAM and aligned to the requested alignment.
+func (a *AddressSpace) Allocate(req MMIOAllocationRequest) (MMIOAllocation, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if req.Size == 0 {
+		return MMIOAllocation{}, fmt.Errorf("address_space: cannot allocate zero-size region for %s", req.Name)
+	}
+
+	alignment := req.Alignment
+	if alignment == 0 {
+		alignment = 0x1000 // Default to 4KB alignment
+	}
+
+	// Ensure alignment is a power of 2
+	if alignment&(alignment-1) != 0 {
+		return MMIOAllocation{}, fmt.Errorf("address_space: alignment 0x%x is not a power of 2 for %s", alignment, req.Name)
+	}
+
+	// Align the base address
+	base := alignUp(a.nextMMIO, alignment)
+
+	// Align the size up to alignment boundary
+	size := alignUp(req.Size, alignment)
+
+	alloc := MMIOAllocation{
+		Name: req.Name,
+		Base: base,
+		Size: size,
+	}
+
+	a.allocations = append(a.allocations, alloc)
+	a.nextMMIO = base + size
+
+	return alloc, nil
+}
+
+// RegisterFixed registers a pre-determined MMIO region.
+// Returns error if the region overlaps with RAM.
+func (a *AddressSpace) RegisterFixed(name string, base, size uint64) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if size == 0 {
+		return fmt.Errorf("address_space: cannot register zero-size fixed region %s", name)
+	}
+
+	ramEnd := a.ramBase + a.ramSize
+
+	// Check for overlap with RAM
+	regionEnd := base + size
+	if base < ramEnd && regionEnd > a.ramBase {
+		return fmt.Errorf("address_space: fixed region %s [0x%x-0x%x) overlaps RAM [0x%x-0x%x)",
+			name, base, regionEnd, a.ramBase, ramEnd)
+	}
+
+	a.fixedRegions = append(a.fixedRegions, MMIOAllocation{
+		Name: name,
+		Base: base,
+		Size: size,
+	})
+
+	return nil
+}
+
+// Allocations returns a copy of all dynamically allocated MMIO regions.
+func (a *AddressSpace) Allocations() []MMIOAllocation {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	result := make([]MMIOAllocation, len(a.allocations))
+	copy(result, a.allocations)
+	return result
+}
+
+// FixedRegions returns a copy of all fixed MMIO regions.
+func (a *AddressSpace) FixedRegions() []MMIOAllocation {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	result := make([]MMIOAllocation, len(a.fixedRegions))
+	copy(result, a.fixedRegions)
+	return result
+}
+
+// RAMBase returns the RAM base address.
+func (a *AddressSpace) RAMBase() uint64 {
+	return a.ramBase
+}
+
+// RAMSize returns the RAM size.
+func (a *AddressSpace) RAMSize() uint64 {
+	return a.ramSize
+}
+
+// RAMEnd returns the first address after RAM.
+func (a *AddressSpace) RAMEnd() uint64 {
+	return a.ramBase + a.ramSize
+}
+
+// Architecture returns the CPU architecture.
+func (a *AddressSpace) Architecture() CpuArchitecture {
+	return a.arch
+}
+
+// alignUp aligns value up to the specified alignment.
+func alignUp(value, align uint64) uint64 {
+	if align == 0 {
+		return value
+	}
+	mask := align - 1
+	return (value + mask) &^ mask
+}

--- a/internal/hv/hvf/bindings/bindings_darwin_arm64.go
+++ b/internal/hv/hvf/bindings/bindings_darwin_arm64.go
@@ -150,6 +150,7 @@ func Load() error {
 
 		purego.RegisterLibFunc(&mach_task_self, libSystemLib, "mach_task_self")
 		purego.RegisterLibFunc(&vm_copy, libSystemLib, "vm_copy")
+		purego.RegisterLibFunc(&os_release, libSystemLib, "os_release")
 	})
 	return loadErr
 }
@@ -284,6 +285,7 @@ var (
 var (
 	mach_task_self func() uint32
 	vm_copy        func(targetTask uint32, sourceAddr uintptr, size uintptr, destAddr uintptr) int32
+	os_release     func(obj uintptr)
 )
 
 // VmCopy performs a copy-on-write memory copy using the Mach vm_copy syscall.
@@ -295,4 +297,12 @@ func VmCopy(source, dest uintptr, size uintptr) error {
 		return fmt.Errorf("vm_copy failed with kern_return_t: %d", ret)
 	}
 	return nil
+}
+
+// OsRelease releases an os_object (such as VMConfig, VcpuConfig, GICConfig, GICState).
+// These objects are reference-counted and must be released to avoid resource leaks.
+func OsRelease(obj uintptr) {
+	if obj != 0 {
+		os_release(obj)
+	}
 }

--- a/internal/hv/hvf/bindings/bindings_darwin_arm64.go
+++ b/internal/hv/hvf/bindings/bindings_darwin_arm64.go
@@ -15,6 +15,7 @@ var (
 	loadErr  error
 
 	hypervisorLib uintptr
+	libSystemLib  uintptr
 )
 
 // Load loads Hypervisor.framework and binds all arm64-exported Hypervisor APIs.
@@ -136,6 +137,19 @@ func Load() error {
 
 		// SME config
 		purego.RegisterLibFunc(&hv_sme_config_get_max_svl_bytes, hypervisorLib, "hv_sme_config_get_max_svl_bytes")
+
+		// Load libSystem for Mach VM functions (vm_copy for COW)
+		libSystemLib, err = purego.Dlopen(
+			"/usr/lib/libSystem.B.dylib",
+			purego.RTLD_GLOBAL|purego.RTLD_LAZY,
+		)
+		if err != nil {
+			loadErr = fmt.Errorf("purego dlopen libSystem: %w", err)
+			return
+		}
+
+		purego.RegisterLibFunc(&mach_task_self, libSystemLib, "mach_task_self")
+		purego.RegisterLibFunc(&vm_copy, libSystemLib, "vm_copy")
 	})
 	return loadErr
 }
@@ -265,3 +279,20 @@ var (
 var (
 	hv_sme_config_get_max_svl_bytes func(value *uintptr) Return
 )
+
+// Mach VM functions (from libSystem)
+var (
+	mach_task_self func() uint32
+	vm_copy        func(targetTask uint32, sourceAddr uintptr, size uintptr, destAddr uintptr) int32
+)
+
+// VmCopy performs a copy-on-write memory copy using the Mach vm_copy syscall.
+// This is an O(1) operation that sets up COW page table entries - the actual
+// page copying is deferred until either source or destination is written to.
+func VmCopy(source, dest uintptr, size uintptr) error {
+	ret := vm_copy(mach_task_self(), source, size, dest)
+	if ret != 0 {
+		return fmt.Errorf("vm_copy failed with kern_return_t: %d", ret)
+	}
+	return nil
+}

--- a/internal/hv/hvf/hvf_darwin_arm64.go
+++ b/internal/hv/hvf/hvf_darwin_arm64.go
@@ -1285,7 +1285,6 @@ func (h *hypervisor) Close() error {
 }
 
 var (
-	tsHvfPreInit              = timeslice.RegisterKind("hvf_pre_init", 0)
 	tsHvfVmCreate             = timeslice.RegisterKind("hvf_vm_create", 0)
 	tsHvfOnCreateVM           = timeslice.RegisterKind("hvf_on_create_vm", 0)
 	tsHvfAllocateMemory       = timeslice.RegisterKind("hvf_allocate_memory", 0)
@@ -1309,8 +1308,6 @@ func (h *hypervisor) NewVirtualMachine(config hv.VMConfig) (hv.VirtualMachine, e
 	}
 
 	vmConfig := bindings.HvVmConfigCreate()
-
-	timeslice.Record(tsHvfPreInit, time.Since(tsHvfStartTime))
 
 	vm := bindings.HvVmCreate(vmConfig)
 	if vm != bindings.HV_SUCCESS {

--- a/internal/hv/hvf/hvf_darwin_arm64.go
+++ b/internal/hv/hvf/hvf_darwin_arm64.go
@@ -62,6 +62,7 @@ const (
 	GuestTsContainerWorkdir  = 62
 	GuestTsContainerDropPriv = 63
 	GuestTsContainerExec     = 64
+	GuestTsContainerComplete = 65
 )
 
 // guestTimesliceNames maps guest timeslice IDs to descriptive names
@@ -103,6 +104,7 @@ var guestTimesliceNames = map[int]string{
 	GuestTsContainerWorkdir:  "guest::container_workdir",
 	GuestTsContainerDropPriv: "guest::container_drop_priv",
 	GuestTsContainerExec:     "guest::container_exec",
+	GuestTsContainerComplete: "guest::container_complete",
 }
 
 // guestTimeslices holds pre-registered timeslice IDs for guest-recorded markers.

--- a/internal/hv/hvf/hvf_darwin_arm64.go
+++ b/internal/hv/hvf/hvf_darwin_arm64.go
@@ -63,6 +63,18 @@ const (
 	GuestTsContainerDropPriv = 63
 	GuestTsContainerExec     = 64
 	GuestTsContainerComplete = 65
+
+	// ForkExecWait phases (66-70)
+	GuestTsForkStart = 66
+	GuestTsForkDone  = 67
+	GuestTsWaitStart = 68
+	GuestTsWaitDone  = 69
+
+	// Command loop phases (70-79)
+	GuestTsContainerCmdLoopStart = 70
+	GuestTsContainerCmdRead      = 71
+	GuestTsContainerCmdExec      = 72
+	GuestTsContainerCmdDone      = 73
 )
 
 // guestTimesliceNames maps guest timeslice IDs to descriptive names
@@ -105,6 +117,18 @@ var guestTimesliceNames = map[int]string{
 	GuestTsContainerDropPriv: "guest::container_drop_priv",
 	GuestTsContainerExec:     "guest::container_exec",
 	GuestTsContainerComplete: "guest::container_complete",
+
+	// ForkExecWait phases
+	GuestTsForkStart: "guest::fork_start",
+	GuestTsForkDone:  "guest::fork_done",
+	GuestTsWaitStart: "guest::wait_start",
+	GuestTsWaitDone:  "guest::wait_done",
+
+	// Command loop phases
+	GuestTsContainerCmdLoopStart: "guest::container_cmd_loop_start",
+	GuestTsContainerCmdRead:      "guest::container_cmd_read",
+	GuestTsContainerCmdExec:      "guest::container_cmd_exec",
+	GuestTsContainerCmdDone:      "guest::container_cmd_done",
 }
 
 // guestTimeslices holds pre-registered timeslice IDs for guest-recorded markers.

--- a/internal/hv/kvm/kvm_amd64.go
+++ b/internal/hv/kvm/kvm_amd64.go
@@ -4,6 +4,7 @@ package kvm
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"unsafe"
@@ -14,6 +15,11 @@ import (
 	"github.com/tinyrange/cc/internal/timeslice"
 	"golang.org/x/sys/unix"
 )
+
+// timesliceMMIOAddr is the MMIO address for guest timeslice recording.
+// Writes to this address record a timeslice marker with the written value as ID.
+// This must match the address used in initx/init_source.go and hvf/hvf_darwin_arm64.go.
+const timesliceMMIOAddr uint64 = 0xf0001000
 
 var (
 	regularRegisters = map[hv.Register]bool{
@@ -344,6 +350,29 @@ func (v *virtualCPU) handleIO(exitCtx *exitContext, ioData *kvmExitIoData) error
 
 func (v *virtualCPU) handleMMIO(exitCtx *exitContext, mmioData *kvmExitMMIOData) error {
 	debug.Writef("kvm-amd64.handleMMIO", "handleMMIO physAddr=0x%016x size=%d isWrite=%d data=% x", mmioData.physAddr, mmioData.len, mmioData.isWrite, mmioData.data)
+
+	// Fast-path: timeslice recording MMIO
+	// This check is done before other processing to minimize overhead.
+	// Guest code writes a timeslice ID to this address for performance instrumentation.
+	if mmioData.physAddr == timesliceMMIOAddr {
+		if mmioData.isWrite != 0 {
+			// Write: Record the timeslice marker
+			size := int(mmioData.len)
+			if size > len(mmioData.data) {
+				size = len(mmioData.data)
+			}
+			var id uint32
+			if size >= 4 {
+				id = binary.LittleEndian.Uint32(mmioData.data[:4])
+			} else if size >= 1 {
+				id = uint32(mmioData.data[0])
+			}
+			// Record the guest timeslice using the ID as the timeslice kind
+			exitCtx.SetExitTimeslice(timeslice.TimesliceID(id))
+		}
+		// For reads, return zeros (no-op, data is already zeroed)
+		return nil
+	}
 
 	cs, err := v.vm.ensureChipset()
 	if err != nil {

--- a/internal/hv/riscv/riscv.go
+++ b/internal/hv/riscv/riscv.go
@@ -122,8 +122,8 @@ func (v *virtualMachine) AddDevice(dev hv.Device) error {
 	return fmt.Errorf("riscv: device support not implemented")
 }
 
-func (v *virtualMachine) AddDeviceFromTemplate(template hv.DeviceTemplate) error {
-	return fmt.Errorf("riscv: device template support not implemented")
+func (v *virtualMachine) AddDeviceFromTemplate(template hv.DeviceTemplate) (hv.Device, error) {
+	return nil, fmt.Errorf("riscv: device template support not implemented")
 }
 
 func (v *virtualMachine) AllocateMemory(physAddr, size uint64) (hv.MemoryRegion, error) {

--- a/internal/initx/container_init_source.go
+++ b/internal/initx/container_init_source.go
@@ -18,7 +18,7 @@ const (
 // 50=container_start, 51=container_mkdir, 52=container_virtiofs, 53=container_mkdir_mnt
 // 54=container_mount_fs, 55=container_chroot, 56=container_devpts, 57=container_qemu
 // 58=container_hostname, 59=container_loopback, 60=container_hosts, 61=container_network
-// 62=container_workdir, 63=container_drop_priv, 64=container_exec
+// 62=container_workdir, 63=container_drop_priv, 64=container_exec, 65=continer_complete
 
 // main is the entrypoint for the container init program.
 // Helper function bodies are replaced at IR level with actual implementations.
@@ -237,6 +237,12 @@ func main() int64 {
 		forkExecWait()
 	}
 
+	// === Phase 11: Complete
+	// Record: continer_complete (65)
+	if timesliceMem > 0 {
+		runtime.Store32(timesliceMem, 0, 65)
+	}
+
 	return 0
 }
 
@@ -335,7 +341,7 @@ func setHostsFile() int64 {
 // configureInterface configures the network interface.
 // This is a placeholder - body is replaced at IR level with actual implementation.
 func configureInterface() int64 { return 0 }
-func addDefaultRoute() int64     { return 0 }
+func addDefaultRoute() int64    { return 0 }
 
 // setResolvConf writes /etc/resolv.conf with the DNS server.
 // The resolv.conf content is provided via the "resolv_content" config value.
@@ -368,9 +374,9 @@ func changeWorkDir() int64 {
 	runtime.Syscall(runtime.SYS_CHDIR, ptr)
 	return 0
 }
-func execCommand() int64      { return 0 }
-func forkExecWait() int64     { return 0 }
-func dropPrivileges() int64   { return 0 }
+func execCommand() int64        { return 0 }
+func forkExecWait() int64       { return 0 }
+func dropPrivileges() int64     { return 0 }
 func setupQEMUEmulation() int64 { return 0 }
 
 // reboot issues a reboot syscall with the architecture-appropriate command.

--- a/internal/initx/helpers.go
+++ b/internal/initx/helpers.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 
 	"github.com/tinyrange/cc/internal/asm"
+	"github.com/tinyrange/cc/internal/hv"
 	"github.com/tinyrange/cc/internal/ir"
 	"github.com/tinyrange/cc/internal/linux/defs"
 	linux "github.com/tinyrange/cc/internal/linux/defs/amd64"
@@ -1184,13 +1185,60 @@ func Exec(path string, argv []string, envp []string, errLabel ir.Label, errVar i
 	})
 }
 
+// Timeslice MMIO constants for ForkExecWait instrumentation
+const (
+	forkExecTimeslicePhysAddr = 0xf0001000
+	forkExecTimesliceMapSize  = 0x1000
+
+	// Timeslice IDs - must match hvf_darwin_arm64.go
+	tsForkStart = 66
+	tsForkDone  = 67
+	tsWaitStart = 68
+	tsWaitDone  = 69
+)
+
 func ForkExecWait(path string, argv []string, envp []string, errLabel ir.Label, errVar ir.Var) ir.Fragment {
 	pid := ir.Var("pid")
 	status := ir.Var("waitStatus")
 	signal := ir.Var("waitSignal")
 	exitCode := ir.Var("waitExitCode")
+	tsMemFd := ir.Var("forkExecTsMemFd")
+	tsPtr := ir.Var("forkExecTsPtr")
+
+	// Helper to emit a timeslice marker (writes ID to MMIO if mapped)
+	emitTs := func(id int64) ir.Fragment {
+		return ir.If(ir.IsGreaterThan(tsPtr, ir.Int64(0)), ir.Block{
+			ir.Assign(tsPtr.Mem().As32(), ir.Int32(int32(id))),
+		})
+	}
 
 	return ir.Block{
+		// Map timeslice MMIO region for instrumentation
+		ir.Assign(tsPtr, ir.Int64(0)),
+		ir.Assign(tsMemFd, ir.Syscall(
+			defs.SYS_OPENAT,
+			ir.Int64(linux.AT_FDCWD),
+			"/dev/mem",
+			ir.Int64(linux.O_RDWR|linux.O_SYNC),
+			ir.Int64(0),
+		)),
+		ir.If(ir.IsGreaterOrEqual(tsMemFd, ir.Int64(0)), ir.Block{
+			ir.Assign(tsPtr, ir.Syscall(
+				defs.SYS_MMAP,
+				ir.Int64(0),
+				ir.Int64(forkExecTimesliceMapSize),
+				ir.Int64(linux.PROT_READ|linux.PROT_WRITE),
+				ir.Int64(linux.MAP_SHARED),
+				tsMemFd,
+				ir.Int64(forkExecTimeslicePhysAddr),
+			)),
+			ir.Syscall(defs.SYS_CLOSE, tsMemFd),
+			ir.If(ir.IsNegative(tsPtr), ir.Assign(tsPtr, ir.Int64(0))),
+		}),
+
+		// Emit: fork_start (66)
+		emitTs(tsForkStart),
+
 		ir.Assign(pid, ir.Syscall(defs.SYS_CLONE, ir.Int64(defs.SIGCHLD), 0, 0, 0, 0)),
 		ir.If(ir.IsNegative(pid), ir.Block{
 			ir.Assign(errVar, pid),
@@ -1201,6 +1249,10 @@ func ForkExecWait(path string, argv []string, envp []string, errLabel ir.Label, 
 			Exec(path, argv, envp, errLabel, errVar),
 			ir.Syscall(defs.SYS_EXIT, ir.Int64(1)),
 		}),
+
+		// Emit: fork_done (67) - parent continues here
+		emitTs(tsForkDone),
+
 		// Parent
 		ir.WithStackSlot(ir.StackSlotConfig{
 			Size: 8,
@@ -1208,7 +1260,15 @@ func ForkExecWait(path string, argv []string, envp []string, errLabel ir.Label, 
 				ptr := ir.Var("statusPtr")
 				return ir.Block{
 					ir.Assign(ptr, slot.Pointer()),
+
+					// Emit: wait_start (68)
+					emitTs(tsWaitStart),
+
 					ir.Assign(errVar, ir.Syscall(defs.SYS_WAIT4, pid, ptr, ir.Int64(0), ir.Int64(0))),
+
+					// Emit: wait_done (69)
+					emitTs(tsWaitDone),
+
 					ir.If(ir.IsNegative(errVar), ir.Goto(errLabel)),
 					ir.Assign(status, ptr.Mem().As32()),
 					ir.Assign(signal, ir.Op(ir.OpAnd, status, ir.Int64(0x7f))),
@@ -1223,6 +1283,303 @@ func ForkExecWait(path string, argv []string, envp []string, errLabel ir.Label, 
 					ir.Assign(errVar, exitCode),
 				}
 			},
+		}),
+
+		// Unmap timeslice region
+		ir.If(ir.IsGreaterThan(tsPtr, ir.Int64(0)), ir.Block{
+			ir.Syscall(defs.SYS_MUNMAP, tsPtr, ir.Int64(forkExecTimesliceMapSize)),
+		}),
+	}
+}
+
+// Config region command format constants
+const (
+	fecConfigRegionPhysAddr = 0xf0003000
+	fecConfigRegionSize     = 4 * 1024 * 1024
+	fecExecCmdRegionOffset  = 0x100000
+	fecExecCmdPathLenOffset = 4
+	fecExecCmdArgcOffset    = 8
+	fecExecCmdEnvcOffset    = 12
+	fecExecCmdDataOffset    = 16
+)
+
+// ForkExecWaitFromConfig is like ForkExecWait but reads the command from config region.
+// The config region command is at offset fecExecCmdRegionOffset with format:
+// - magic(4) + path_len(4) + argc(4) + envc(4) + data
+// Where data is: path\0 + args\0...\0 + envs\0...\0
+//
+// This is used by the command loop mode for late snapshots, where the command
+// is not baked into the init program but passed at runtime via WriteExecCommand.
+//
+// configRegionPhysAddr and timeslicePhysAddr are the physical addresses of the
+// MMIO regions (dynamically allocated by the hypervisor). If 0, defaults are used.
+func ForkExecWaitFromConfig(arch hv.CpuArchitecture, defaultEnv []string, configRegionPhysAddr, timeslicePhysAddr uint64, errLabel ir.Label, errVar ir.Var) ir.Fragment {
+	// Use defaults if not specified
+	if configRegionPhysAddr == 0 {
+		configRegionPhysAddr = fecConfigRegionPhysAddr
+	}
+	if timeslicePhysAddr == 0 {
+		timeslicePhysAddr = forkExecTimeslicePhysAddr
+	}
+	pid := ir.Var("fec_pid")
+	status := ir.Var("fec_status")
+	signal := ir.Var("fec_signal")
+	exitCode := ir.Var("fec_exit_code")
+	memFd := ir.Var("fec_mem_fd")
+	configMem := ir.Var("fec_config_mem")
+	tsPtr := ir.Var("fec_ts_ptr")
+
+	// Command parsing variables
+	dataPtr := ir.Var("fec_data_ptr")
+	pathLen := ir.Var("fec_path_len")
+	argc := ir.Var("fec_argc")
+	envc := ir.Var("fec_envc")
+
+	// Local variables
+	pathPtr := ir.Var("fec_path_ptr")
+	argvPtr := ir.Var("fec_argv_ptr")
+	envpPtr := ir.Var("fec_envp_ptr")
+	currentPtr := ir.Var("fec_current_ptr")
+	argIdx := ir.Var("fec_arg_idx")
+	envIdx := ir.Var("fec_env_idx")
+	charVal := ir.Var("fec_char_val")
+
+	argLoop := nextHelperLabel("fec_arg_loop")
+	argFindNull := nextHelperLabel("fec_arg_find_null")
+	envLoop := nextHelperLabel("fec_env_loop")
+	envFindNull := nextHelperLabel("fec_env_find_null")
+
+	// Helper to emit a timeslice marker (writes ID to MMIO if mapped)
+	emitTs := func(id int64) ir.Fragment {
+		return ir.If(ir.IsGreaterThan(tsPtr, ir.Int64(0)), ir.Block{
+			ir.Assign(tsPtr.Mem().As32(), ir.Int32(int32(id))),
+		})
+	}
+
+	maxPointers := 128 // Support up to 127 args/envs combined
+	slotSize := int64(maxPointers * 8)
+
+	return ir.Block{
+		// Map /dev/mem for config region and timeslice MMIO
+		ir.Assign(configMem, ir.Int64(0)),
+		ir.Assign(tsPtr, ir.Int64(0)),
+		ir.Assign(memFd, ir.Syscall(
+			defs.SYS_OPENAT,
+			ir.Int64(linux.AT_FDCWD),
+			"/dev/mem",
+			ir.Int64(linux.O_RDWR|linux.O_SYNC),
+			ir.Int64(0),
+		)),
+		ir.If(ir.IsGreaterOrEqual(memFd, ir.Int64(0)), ir.Block{
+			// Map config region
+			ir.Assign(configMem, ir.Syscall(
+				defs.SYS_MMAP,
+				ir.Int64(0),
+				ir.Int64(fecConfigRegionSize),
+				ir.Int64(linux.PROT_READ|linux.PROT_WRITE),
+				ir.Int64(linux.MAP_SHARED),
+				memFd,
+				ir.Int64(int64(configRegionPhysAddr)),
+			)),
+			ir.If(ir.IsNegative(configMem), ir.Assign(configMem, ir.Int64(0))),
+
+			// Map timeslice MMIO region
+			ir.Assign(tsPtr, ir.Syscall(
+				defs.SYS_MMAP,
+				ir.Int64(0),
+				ir.Int64(forkExecTimesliceMapSize),
+				ir.Int64(linux.PROT_READ|linux.PROT_WRITE),
+				ir.Int64(linux.MAP_SHARED),
+				memFd,
+				ir.Int64(int64(timeslicePhysAddr)),
+			)),
+			ir.If(ir.IsNegative(tsPtr), ir.Assign(tsPtr, ir.Int64(0))),
+
+			ir.Syscall(defs.SYS_CLOSE, memFd),
+		}),
+
+		// Check if config region was mapped
+		ir.If(ir.IsZero(configMem), ir.Block{
+			ir.Printf("cc: failed to map config region for command\n"),
+			ir.Assign(errVar, ir.Int64(-1)),
+			ir.Goto(errLabel),
+		}),
+
+		// Read command header from config region
+		// First compute base address for command region
+		ir.Assign(ir.Var("fec_cmd_base"), ir.Op(ir.OpAdd, configMem, ir.Int64(fecExecCmdRegionOffset))),
+		ir.Assign(pathLen, ir.Var("fec_cmd_base").MemWithDisp(fecExecCmdPathLenOffset).As32()),
+		ir.Assign(argc, ir.Var("fec_cmd_base").MemWithDisp(fecExecCmdArgcOffset).As32()),
+		ir.Assign(envc, ir.Var("fec_cmd_base").MemWithDisp(fecExecCmdEnvcOffset).As32()),
+		ir.Assign(dataPtr, ir.Op(ir.OpAdd, ir.Var("fec_cmd_base"), ir.Int64(fecExecCmdDataOffset))),
+
+		ir.WithStackSlot(ir.StackSlotConfig{
+			Size: slotSize,
+			Body: func(slot ir.StackSlot) ir.Fragment {
+				return ir.Block{
+					// pathPtr points to the path string in the config region data
+					ir.Assign(pathPtr, dataPtr),
+
+					// argv array starts at slot base
+					ir.Assign(argvPtr, slot.Pointer()),
+
+					// Skip path to find start of args
+					// currentPtr = dataPtr + pathLen + 1 (skip null terminator)
+					ir.Assign(currentPtr, ir.Op(ir.OpAdd, dataPtr, pathLen)),
+					ir.Assign(currentPtr, ir.Op(ir.OpAdd, currentPtr, ir.Int64(1))),
+
+					// Build argv array: first entry is path, then args from config
+					ir.Assign(slot.At(0), pathPtr),
+					ir.Assign(argIdx, ir.Int64(1)),
+
+					// Copy arg pointers
+					ir.DeclareLabel(argLoop, ir.Block{
+						ir.If(ir.IsGreaterOrEqual(argIdx, ir.Op(ir.OpAdd, argc, ir.Int64(1))), ir.Block{
+							// Done with args - store NULL terminator
+							ir.Assign(ir.Var("argv_term_offset"), ir.Op(ir.OpShl, argIdx, ir.Int64(3))),
+							ir.Assign(ir.Var("argv_term_ptr"), ir.Op(ir.OpAdd, argvPtr, ir.Var("argv_term_offset"))),
+							ir.Assign(ir.Var("argv_term_ptr").Mem(), ir.Int64(0)),
+							ir.Goto(envLoop),
+						}),
+						// Store pointer to current arg
+						ir.Assign(ir.Var("argv_offset"), ir.Op(ir.OpShl, argIdx, ir.Int64(3))),
+						ir.Assign(ir.Var("argv_slot_ptr"), ir.Op(ir.OpAdd, argvPtr, ir.Var("argv_offset"))),
+						ir.Assign(ir.Var("argv_slot_ptr").Mem(), currentPtr),
+						// Advance to next arg (find null terminator)
+						ir.Goto(argFindNull),
+					}),
+
+					ir.DeclareLabel(argFindNull, ir.Block{
+						ir.Assign(charVal, currentPtr.Mem().As8()),
+						ir.Assign(currentPtr, ir.Op(ir.OpAdd, currentPtr, ir.Int64(1))),
+						ir.If(ir.IsNotEqual(charVal, ir.Int64(0)), ir.Goto(argFindNull)),
+						// Found null, currentPtr now points to next arg
+						ir.Assign(argIdx, ir.Op(ir.OpAdd, argIdx, ir.Int64(1))),
+						ir.Goto(argLoop),
+					}),
+
+					ir.DeclareLabel(envLoop, ir.Block{
+						// envpPtr = argvPtr + (argc + 2) * 8 (argc + 1 for path, + 1 for NULL terminator)
+						ir.Assign(envpPtr, ir.Op(ir.OpShl, ir.Op(ir.OpAdd, argc, ir.Int64(2)), ir.Int64(3))),
+						ir.Assign(envpPtr, ir.Op(ir.OpAdd, argvPtr, envpPtr)),
+
+						// First, add default environment variables
+						func() ir.Fragment {
+							var frags []ir.Fragment
+							for i, env := range defaultEnv {
+								ptrVar := ir.Var(fmt.Sprintf("fec_defenv_%d_ptr", i))
+								frags = append(frags,
+									ir.LoadConstantBytesConfig(ir.ConstantBytesConfig{
+										Target:        nextExecVar(),
+										Data:          []byte(env),
+										ZeroTerminate: true,
+										Pointer:       ptrVar,
+									}),
+									ir.Assign(ir.Var("envp_offset"), ir.Int64(int64(i*8))),
+									ir.Assign(ir.Var("envp_slot_ptr"), ir.Op(ir.OpAdd, envpPtr, ir.Var("envp_offset"))),
+									ir.Assign(ir.Var("envp_slot_ptr").Mem(), ptrVar),
+								)
+							}
+							return ir.Block(frags)
+						}(),
+
+						// Now add environment from config region
+						ir.Assign(envIdx, ir.Int64(int64(len(defaultEnv)))),
+						ir.Goto(ir.Label("fec_env_copy_loop")),
+					}),
+
+					ir.DeclareLabel(ir.Label("fec_env_copy_loop"), ir.Block{
+						ir.If(ir.IsGreaterOrEqual(envIdx, ir.Op(ir.OpAdd, envc, ir.Int64(int64(len(defaultEnv))))), ir.Block{
+							// Done with envs - store NULL terminator
+							ir.Assign(ir.Var("envp_term_offset"), ir.Op(ir.OpShl, envIdx, ir.Int64(3))),
+							ir.Assign(ir.Var("envp_term_ptr"), ir.Op(ir.OpAdd, envpPtr, ir.Var("envp_term_offset"))),
+							ir.Assign(ir.Var("envp_term_ptr").Mem(), ir.Int64(0)),
+							ir.Goto(ir.Label("fec_do_fork")),
+						}),
+						// Store pointer to current env
+						ir.Assign(ir.Var("envp_offset"), ir.Op(ir.OpShl, envIdx, ir.Int64(3))),
+						ir.Assign(ir.Var("envp_slot_ptr"), ir.Op(ir.OpAdd, envpPtr, ir.Var("envp_offset"))),
+						ir.Assign(ir.Var("envp_slot_ptr").Mem(), currentPtr),
+						// Advance to next env (find null terminator)
+						ir.Goto(envFindNull),
+					}),
+
+					ir.DeclareLabel(envFindNull, ir.Block{
+						ir.Assign(charVal, currentPtr.Mem().As8()),
+						ir.Assign(currentPtr, ir.Op(ir.OpAdd, currentPtr, ir.Int64(1))),
+						ir.If(ir.IsNotEqual(charVal, ir.Int64(0)), ir.Goto(envFindNull)),
+						// Found null, currentPtr now points to next env
+						ir.Assign(envIdx, ir.Op(ir.OpAdd, envIdx, ir.Int64(1))),
+						ir.Goto(ir.Label("fec_env_copy_loop")),
+					}),
+
+					ir.DeclareLabel(ir.Label("fec_do_fork"), ir.Block{
+						// Emit: fork_start (66)
+						emitTs(tsForkStart),
+
+						ir.Assign(pid, ir.Syscall(defs.SYS_CLONE, ir.Int64(defs.SIGCHLD), 0, 0, 0, 0)),
+						ir.If(ir.IsNegative(pid), ir.Block{
+							ir.Assign(errVar, pid),
+							ir.Goto(errLabel),
+						}),
+						ir.If(ir.IsZero(pid), ir.Block{
+							// Child: exec the command
+							ir.Assign(errVar, ir.Syscall(
+								defs.SYS_EXECVE,
+								pathPtr,
+								argvPtr,
+								envpPtr,
+							)),
+							// If execve returns, it failed
+							ir.Printf("cc: execve failed: errno=0x%x\n", ir.Op(ir.OpSub, ir.Int64(0), errVar)),
+							ir.Syscall(defs.SYS_EXIT, ir.Int64(1)),
+						}),
+
+						// Emit: fork_done (67) - parent continues here
+						emitTs(tsForkDone),
+
+						// Parent: wait for child
+						ir.WithStackSlot(ir.StackSlotConfig{
+							Size: 8,
+							Body: func(statusSlot ir.StackSlot) ir.Fragment {
+								statusPtr := ir.Var("fec_status_ptr")
+								return ir.Block{
+									ir.Assign(statusPtr, statusSlot.Pointer()),
+
+									// Emit: wait_start (68)
+									emitTs(tsWaitStart),
+
+									ir.Assign(errVar, ir.Syscall(defs.SYS_WAIT4, pid, statusPtr, ir.Int64(0), ir.Int64(0))),
+
+									// Emit: wait_done (69)
+									emitTs(tsWaitDone),
+
+									ir.If(ir.IsNegative(errVar), ir.Goto(errLabel)),
+									ir.Assign(status, statusPtr.Mem().As32()),
+									ir.Assign(signal, ir.Op(ir.OpAnd, status, ir.Int64(0x7f))),
+									ir.Assign(exitCode, ir.Op(
+										ir.OpAnd,
+										ir.Op(ir.OpShr, status, ir.Int64(8)),
+										ir.Int64(0xff),
+									)),
+									ir.If(ir.IsNotEqual(signal, ir.Int64(0)), ir.Block{
+										ir.Assign(exitCode, ir.Op(ir.OpAdd, signal, ir.Int64(128))),
+									}),
+									ir.Assign(errVar, exitCode),
+								}
+							},
+						}),
+					}),
+				}
+			},
+		}),
+
+		// Unmap regions
+		ir.If(ir.IsGreaterThan(tsPtr, ir.Int64(0)), ir.Block{
+			ir.Syscall(defs.SYS_MUNMAP, tsPtr, ir.Int64(forkExecTimesliceMapSize)),
+		}),
+		ir.If(ir.IsGreaterThan(configMem, ir.Int64(0)), ir.Block{
+			ir.Syscall(defs.SYS_MUNMAP, configMem, ir.Int64(fecConfigRegionSize)),
 		}),
 	}
 }

--- a/internal/initx/init.go
+++ b/internal/initx/init.go
@@ -3,6 +3,7 @@ package initx
 import (
 	_ "embed"
 	"fmt"
+	"strings"
 
 	"github.com/tinyrange/cc/internal/hv"
 	"github.com/tinyrange/cc/internal/ir"
@@ -24,6 +25,14 @@ type BuilderConfig struct {
 	Arch hv.CpuArchitecture
 
 	PreloadModules []kernel.Module
+
+	// MailboxPhysAddr is the physical address of the mailbox region.
+	// If 0, uses the default value (for backwards compatibility).
+	MailboxPhysAddr uint64
+
+	// ConfigRegionPhysAddr is the physical address of the config region.
+	// If 0, uses the default value (for backwards compatibility).
+	ConfigRegionPhysAddr uint64
 }
 
 const (
@@ -123,8 +132,25 @@ func BuildFromRTG(cfg BuilderConfig) (*ir.Program, error) {
 		return nil, fmt.Errorf("unsupported architecture for RTG init: %s", cfg.Arch)
 	}
 
+	// Preprocess the source to inject dynamic MMIO addresses
+	source := rtgInitSource
+	if cfg.MailboxPhysAddr != 0 {
+		// Replace the hard-coded mailboxPhysAddr constant
+		source = strings.Replace(source,
+			"mailboxPhysAddr      = 0xf0000000",
+			fmt.Sprintf("mailboxPhysAddr      = 0x%x", cfg.MailboxPhysAddr),
+			1)
+	}
+	if cfg.ConfigRegionPhysAddr != 0 {
+		// Replace the hard-coded configRegionPhysAddr constant
+		source = strings.Replace(source,
+			"configRegionPhysAddr = 0xf0003000",
+			fmt.Sprintf("configRegionPhysAddr = 0x%x", cfg.ConfigRegionPhysAddr),
+			1)
+	}
+
 	// Compile the RTG source with architecture information
-	prog, err := rtg.CompileProgramWithOptions(rtgInitSource, rtg.CompileOptions{
+	prog, err := rtg.CompileProgramWithOptions(source, rtg.CompileOptions{
 		GOARCH: goarch,
 	})
 	if err != nil {

--- a/internal/initx/init.go
+++ b/internal/initx/init.go
@@ -30,6 +30,11 @@ type BuilderConfig struct {
 	// If 0, uses the default value (for backwards compatibility).
 	MailboxPhysAddr uint64
 
+	// TimesliceMMIOPhysAddr is the physical address of the timeslice MMIO region.
+	// Guest code can write to this address to record timeslice markers.
+	// If 0, uses the default value 0xf0001000.
+	TimesliceMMIOPhysAddr uint64
+
 	// ConfigRegionPhysAddr is the physical address of the config region.
 	// If 0, uses the default value (for backwards compatibility).
 	ConfigRegionPhysAddr uint64
@@ -137,15 +142,22 @@ func BuildFromRTG(cfg BuilderConfig) (*ir.Program, error) {
 	if cfg.MailboxPhysAddr != 0 {
 		// Replace the hard-coded mailboxPhysAddr constant
 		source = strings.Replace(source,
-			"mailboxPhysAddr      = 0xf0000000",
-			fmt.Sprintf("mailboxPhysAddr      = 0x%x", cfg.MailboxPhysAddr),
+			"mailboxPhysAddr        = 0xf0000000",
+			fmt.Sprintf("mailboxPhysAddr        = 0x%x", cfg.MailboxPhysAddr),
+			1)
+	}
+	if cfg.TimesliceMMIOPhysAddr != 0 {
+		// Replace the hard-coded timesliceMMIOPhysAddr constant
+		source = strings.Replace(source,
+			"timesliceMMIOPhysAddr  = 0xf0001000",
+			fmt.Sprintf("timesliceMMIOPhysAddr  = 0x%x", cfg.TimesliceMMIOPhysAddr),
 			1)
 	}
 	if cfg.ConfigRegionPhysAddr != 0 {
 		// Replace the hard-coded configRegionPhysAddr constant
 		source = strings.Replace(source,
-			"configRegionPhysAddr = 0xf0003000",
-			fmt.Sprintf("configRegionPhysAddr = 0x%x", cfg.ConfigRegionPhysAddr),
+			"configRegionPhysAddr   = 0xf0003000",
+			fmt.Sprintf("configRegionPhysAddr   = 0x%x", cfg.ConfigRegionPhysAddr),
 			1)
 	}
 

--- a/internal/initx/loader.go
+++ b/internal/initx/loader.go
@@ -752,6 +752,10 @@ func NewVirtualMachine(
 		}(),
 
 		GetKernel: func() (io.ReaderAt, int64, error) {
+			if kernelLoader == nil {
+				return nil, 0, fmt.Errorf("kernel not loaded (use WithSnapshot for snapshot restore)")
+			}
+
 			size, err := kernelLoader.Size()
 			if err != nil {
 				return nil, 0, fmt.Errorf("get kernel size: %v", err)
@@ -766,10 +770,17 @@ func NewVirtualMachine(
 		},
 
 		GetSystemMap: func() (io.ReaderAt, error) {
+			if kernelLoader == nil {
+				return nil, fmt.Errorf("kernel not loaded (use WithSnapshot for snapshot restore)")
+			}
 			return kernelLoader.GetSystemMap()
 		},
 
 		GetInit: func(arch hv.CpuArchitecture) (*ir.Program, error) {
+			if kernelLoader == nil {
+				return nil, fmt.Errorf("kernel not loaded (use WithSnapshot for snapshot restore)")
+			}
+
 			cfg := BuilderConfig{
 				Arch:                 arch,
 				MailboxPhysAddr:      ret.mailboxPhysAddr,

--- a/internal/ir/amd64/compiler.go
+++ b/internal/ir/amd64/compiler.go
@@ -243,6 +243,17 @@ func (c *compiler) compileAssign(assign ir.AssignFragment) error {
 		}
 		c.freeReg(reg)
 		return nil
+	case ir.CallFragment:
+		// Handle function calls in assignment context
+		// Compile the call, then store the result (RAX) to the destination
+		if err := c.compileCall(src); err != nil {
+			return err
+		}
+		// The call result is in RAX, store it to the destination
+		if err := c.storeValue(assign.Dst, amd64.RAX, ir.Width64); err != nil {
+			return err
+		}
+		return nil
 	default:
 		reg, width, err := c.evalValue(assign.Src)
 		if err != nil {

--- a/internal/ir/arm64/compiler.go
+++ b/internal/ir/arm64/compiler.go
@@ -284,6 +284,17 @@ func (c *compiler) compileAssign(assign ir.AssignFragment) error {
 		}
 		c.freeReg(reg)
 		return nil
+	case ir.CallFragment:
+		// Handle function calls in assignment context
+		// Compile the call, then store the result (X0) to the destination
+		if err := c.compileCall(src); err != nil {
+			return err
+		}
+		// The call result is in X0, store it to the destination
+		if err := c.storeValue(assign.Dst, arm64asm.X0, ir.Width64); err != nil {
+			return err
+		}
+		return nil
 	default:
 		reg, width, err := c.evalValue(assign.Src)
 		if err != nil {

--- a/internal/linux/boot/amd64/bootparams_test.go
+++ b/internal/linux/boot/amd64/bootparams_test.go
@@ -20,7 +20,9 @@ func (s *stubVM) SetIRQ(irqLine uint32, level bool) error                { panic
 func (s *stubVM) CaptureSnapshot() (hv.Snapshot, error)                  { panic("unimplemented") }
 func (s *stubVM) RestoreSnapshot(snap hv.Snapshot) error                 { panic("unimplemented") }
 func (s *stubVM) AddDevice(dev hv.Device) error                          { panic("unimplemented") }
-func (s *stubVM) AddDeviceFromTemplate(template hv.DeviceTemplate) error { panic("unimplemented") }
+func (s *stubVM) AddDeviceFromTemplate(template hv.DeviceTemplate) (hv.Device, error) {
+	panic("unimplemented")
+}
 func (s *stubVM) Close() error                                           { panic("unimplemented") }
 func (s *stubVM) Hypervisor() hv.Hypervisor                              { panic("unimplemented") }
 func (s *stubVM) Run(ctx context.Context, cfg hv.RunConfig) error        { panic("unimplemented") }
@@ -28,6 +30,15 @@ func (s *stubVM) VirtualCPUCall(id int, f func(vcpu hv.VirtualCPU) error) error 
 	panic("unimplemented")
 }
 func (s *stubVM) AllocateMemory(physAddr uint64, size uint64) (hv.MemoryRegion, error) {
+	panic("unimplemented")
+}
+func (s *stubVM) AllocateMMIO(req hv.MMIOAllocationRequest) (hv.MMIOAllocation, error) {
+	panic("unimplemented")
+}
+func (s *stubVM) RegisterFixedMMIO(name string, base, size uint64) error {
+	panic("unimplemented")
+}
+func (s *stubVM) GetAllocatedMMIORegions() []hv.MMIOAllocation {
 	panic("unimplemented")
 }
 

--- a/internal/linux/boot/arm64/kernel.go
+++ b/internal/linux/boot/arm64/kernel.go
@@ -21,6 +21,12 @@ var (
 // LoadKernel parses the supplied ARM64 Image (optionally compressed) and
 // returns an in-memory representation ready for placement into guest RAM.
 func LoadKernel(reader io.ReaderAt, size int64) (*KernelImage, error) {
+	return LoadKernelWithCache(reader, size, "")
+}
+
+// LoadKernelWithCache parses the supplied ARM64 Image with optional caching
+// of decompressed kernels. If cacheDir is empty, no caching is performed.
+func LoadKernelWithCache(reader io.ReaderAt, size int64, cacheDir string) (*KernelImage, error) {
 	rec := timeslice.NewState()
 
 	probe, err := ProbeKernelImage(reader, size)
@@ -30,7 +36,7 @@ func LoadKernel(reader io.ReaderAt, size int64) (*KernelImage, error) {
 
 	rec.Record(tsLinuxLoaderArm64ProbeKernel)
 
-	payload, err := probe.ExtractImage(reader, size)
+	payload, err := probe.ExtractImageCached(reader, size, cacheDir)
 	if err != nil {
 		return nil, fmt.Errorf("extract arm64 kernel image: %w", err)
 	}

--- a/internal/linux/boot/loader.go
+++ b/internal/linux/boot/loader.go
@@ -240,8 +240,7 @@ func (l *LinuxLoader) Load(vm hv.VirtualMachine) error {
 	}
 
 	cmdlineBase := append([]string(nil), cmdline...)
-	var virtioCmdline []string
-	var virtioNodes []fdt.Node
+
 	// Only allocate GSIs on x86. ARM64 virtio devices have architecture-specific
 	// defaults that work correctly with the GIC. Using the x86-style GSI allocator
 	// on ARM64 causes KVM_IRQ_LINE to fail with EINVAL.
@@ -264,31 +263,15 @@ func (l *LinuxLoader) Load(vm hv.VirtualMachine) error {
 		}
 	}
 
-	// DeviceTreeProvider allows any device to provide device tree nodes
-	type DeviceTreeProvider interface {
-		DeviceTreeNodes() ([]fdt.Node, error)
+	// Create devices FIRST to allocate MMIO regions dynamically.
+	// This must happen before generating cmdline/device-tree so we have actual addresses.
+	createdDevices, err := l.createDevicesEarly(vm)
+	if err != nil {
+		return fmt.Errorf("create devices: %w", err)
 	}
 
-	for _, dev := range l.Devices {
-		if vdev, ok := dev.(virtio.VirtioMMIODevice); ok {
-			params, err := vdev.GetLinuxCommandLineParam()
-			if err != nil {
-				return fmt.Errorf("get virtio mmio device linux cmdline param: %w", err)
-			}
-			virtioCmdline = append(virtioCmdline, params...)
-			nodes, err := vdev.DeviceTreeNodes()
-			if err != nil {
-				return fmt.Errorf("get virtio mmio device tree nodes: %w", err)
-			}
-			virtioNodes = append(virtioNodes, nodes...)
-		} else if dtp, ok := dev.(DeviceTreeProvider); ok {
-			nodes, err := dtp.DeviceTreeNodes()
-			if err != nil {
-				return fmt.Errorf("get device tree nodes: %w", err)
-			}
-			virtioNodes = append(virtioNodes, nodes...)
-		}
-	}
+	// Build device tree nodes from created devices using their actual allocated addresses
+	virtioNodes := l.getVirtioDeviceTreeNodes(createdDevices)
 
 	rec.Record(tsLinuxLoaderGotDeviceTreeNodes)
 
@@ -297,7 +280,7 @@ func (l *LinuxLoader) Load(vm hv.VirtualMachine) error {
 		// For x86_64 with ACPI, don't add virtio_mmio command line params
 		// because the devices will be discovered via ACPI DSDT.
 		cmdlineStr := strings.Join(cmdlineBase, " ")
-		return l.loadAMD64(rec, vm, kernelReader, kernelSize, cmdlineStr, initrd)
+		return l.loadAMD64(rec, vm, kernelReader, kernelSize, cmdlineStr, initrd, createdDevices)
 	case hv.ArchitectureARM64:
 		cmdlineStr := strings.Join(cmdlineBase, " ")
 		return l.loadARM64(rec, vm, kernelReader, kernelSize, cmdlineStr, initrd, virtioNodes)
@@ -306,6 +289,32 @@ func (l *LinuxLoader) Load(vm hv.VirtualMachine) error {
 	default:
 		return fmt.Errorf("unsupported architecture: %v", arch)
 	}
+}
+
+// createDevicesEarly creates devices from templates early in the boot process.
+// This is needed so MMIO addresses are allocated before generating cmdline/device-tree.
+func (l *LinuxLoader) createDevicesEarly(vm hv.VirtualMachine) ([]hv.Device, error) {
+	var createdDevices []hv.Device
+	for _, template := range l.Devices {
+		dev, err := vm.AddDeviceFromTemplate(template)
+		if err != nil {
+			return nil, fmt.Errorf("add device from template: %w", err)
+		}
+		createdDevices = append(createdDevices, dev)
+	}
+	return createdDevices, nil
+}
+
+// getVirtioDeviceTreeNodes builds FDT nodes for VirtIO devices using their
+// actual allocated MMIO addresses.
+func (l *LinuxLoader) getVirtioDeviceTreeNodes(devices []hv.Device) []fdt.Node {
+	var nodes []fdt.Node
+	for _, dev := range devices {
+		if vdev, ok := dev.(virtio.AllocatedVirtioMMIODevice); ok {
+			nodes = append(nodes, virtio.GetAllocatedDeviceTreeNode(vdev))
+		}
+	}
+	return nodes
 }
 
 func (l *LinuxLoader) buildInitPayload(arch hv.CpuArchitecture) ([]byte, error) {
@@ -354,7 +363,7 @@ var (
 	tsLinuxLoaderInstalledACPI     = timeslice.RegisterKind("linux_loader_installed_acpi", 0)
 )
 
-func (l *LinuxLoader) loadAMD64(rec *timeslice.Recorder, vm hv.VirtualMachine, kernelReader io.ReaderAt, kernelSize int64, cmdline string, initrd []byte) error {
+func (l *LinuxLoader) loadAMD64(rec *timeslice.Recorder, vm hv.VirtualMachine, kernelReader io.ReaderAt, kernelSize int64, cmdline string, initrd []byte, createdDevices []hv.Device) error {
 	kernelImage, err := amd64boot.LoadKernel(kernelReader, kernelSize)
 	if err != nil {
 		return fmt.Errorf("load kernel: %w", err)
@@ -545,19 +554,14 @@ func (l *LinuxLoader) loadAMD64(rec *timeslice.Recorder, vm hv.VirtualMachine, k
 		return fmt.Errorf("add i8042 controller: %w", err)
 	}
 
-	for _, dev := range l.Devices {
-		if err := vm.AddDeviceFromTemplate(dev); err != nil {
-			return fmt.Errorf("add device from template: %w", err)
-		}
-	}
-
+	// Devices were already created earlier via createDevicesEarly()
 	rec.Record(tsLinuxLoaderAddedDevices)
 
-	// Collect virtio-mmio device info for ACPI DSDT
+	// Collect virtio-mmio device info for ACPI DSDT using actual allocated addresses
 	var virtioACPIDevices []acpi.VirtioMMIODevice
-	for i, dev := range l.Devices {
-		if vdev, ok := dev.(virtio.VirtioMMIODevice); ok {
-			info := vdev.GetACPIDeviceInfo()
+	for i, dev := range createdDevices {
+		if vdev, ok := dev.(virtio.AllocatedVirtioMMIODevice); ok {
+			info := virtio.GetAllocatedACPIDeviceInfo(vdev)
 			virtioACPIDevices = append(virtioACPIDevices, acpi.VirtioMMIODevice{
 				Name:     fmt.Sprintf("VIO%d", i),
 				BaseAddr: info.BaseAddr,
@@ -718,12 +722,7 @@ func (l *LinuxLoader) loadARM64(rec *timeslice.Recorder, vm hv.VirtualMachine, k
 
 	rec.Record(tsLinuxLoaderAddedUART)
 
-	for _, dev := range l.Devices {
-		if err := vm.AddDeviceFromTemplate(dev); err != nil {
-			return fmt.Errorf("add device from template: %w", err)
-		}
-	}
-
+	// Devices were already created earlier via createDevicesEarly()
 	rec.Record(tsLinuxLoaderAddedDevices)
 
 	return nil

--- a/tools/build.go
+++ b/tools/build.go
@@ -1149,6 +1149,7 @@ func main() {
 	benchTests := fs.Bool("bench-tests", false, "build and run the benchmark tests")
 	snapshotE2E := fs.Bool("snapshot-e2e", false, "build and run snapshot e2e benchmark")
 	release := fs.Bool("release", false, "build a release binary")
+	runSpecial := fs.String("runs", "", "run a given package")
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		os.Exit(1)
@@ -1846,6 +1847,26 @@ func main() {
 
 			fmt.Println("cross-platform release build completed!")
 		}
+		return
+	}
+
+	if *runSpecial != "" {
+		out, err := goBuild(buildOptions{
+			Package:          *runSpecial,
+			OutputName:       filepath.Base(*runSpecial),
+			Build:            buildTarget,
+			EntitlementsPath: filepath.Join("tools", "entitlements.xml"),
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to build special: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("running %s %+v\n", out.Path, flag.Args())
+		if err := runBuildOutput(out, flag.Args(), runOpts); err != nil {
+			os.Exit(1)
+		}
+
 		return
 	}
 

--- a/tools/build.go
+++ b/tools/build.go
@@ -1862,8 +1862,8 @@ func main() {
 			os.Exit(1)
 		}
 
-		fmt.Printf("running %s %+v\n", out.Path, flag.Args())
-		if err := runBuildOutput(out, flag.Args(), runOpts); err != nil {
+		fmt.Printf("running %s %+v\n", out.Path, fs.Args())
+		if err := runBuildOutput(out, fs.Args(), runOpts); err != nil {
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
Up to 270 VMs/second on M4 Macbook Air.

Includes a fix for the 1GB of ram limitaiton.

Needs testing to make sure there are no regressions on....

- [x] linux arm64
- [ ] windows arm64
- [x] linux amd64
- [x] windows amd64

Closes #65

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Accelerates VM startup and improves portability/stability with snapshotting, dynamic MMIO, and perf tooling.
> 
> - Adds CommandLoop-based snapshot caching in `ccapp` and `internal/cmd/cc` (compute/load/save snapshots, write/clear exec command); user setting `snapshot_cache_enabled`
> - Implements dynamic MMIO allocation via new `hv.AddressSpace` and VM APIs (`AllocateMMIO`, `RegisterFixedMMIO`, `GetAllocatedMMIORegions`); VirtIO devices (fs/net/gpu/input/console) now allocate/report actual addresses
> - Updates Linux loader to create devices early and generate ACPI/FDT using allocated addresses; removes ARM64 memory cap and supports snapshot restore via `WithSnapshot`
> - HV backends (HVF/KVM/WHP) implement new MMIO APIs; HVF gains COW snapshotting (Mach `vm_copy`), proper object release, vtimer drift adjustment, and fast-path timeslice MMIO; KVM/WHP add timeslice MMIO fast-paths
> - Container/init RTG: add command-loop mode, dynamic MMIO address injection, exec-from-config, and rich guest timeslice markers; init maps timeslice/config/mailbox regions
> - ARM64 kernel loader adds decompression caching (on-disk), reducing boot overhead
> - New `internal/cmd/benchmark` tool to measure snapshot/command-loop performance; misc tweaks (codesign log, timeslice output); tests updated for new VM interfaces
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52d2b121b2030190897f381f0355417946929e93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->