### PR TITLE
Perf pass for Linux arm64

### DIFF
--- a/internal/cmd/quest/main.go
+++ b/internal/cmd/quest/main.go
@@ -1356,7 +1356,7 @@ func (q *bringUpQuest) RunLinux() error {
 			}, nil
 		},
 
-		SerialStdout: os.Stdout,
+		SerialStdout: io.MultiWriter(os.Stdout, buf),
 
 		Devices: devices,
 	}


### PR DESCRIPTION
About 150 VMs/second on a M1 Macbook Air running Asahi Linux
About 56 VMs/second on a Raspberry PI 5

Closes #62 

The test now uses a slightly different design with the same VM used each time. This actually decreases performance slightly but is needed on arm64 Linux for some unknown reason.