### PR TITLE
bindings: fix IPC cmd pipes and helper source config

### DIFF
--- a/bindings/c/instance_proxy.go
+++ b/bindings/c/instance_proxy.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"io"
 	"io/fs"
 	"net"
@@ -888,17 +887,55 @@ func (c *cmdProxy) ExitCode() int {
 	return c.exitCode
 }
 
-// Pipe methods - not supported over IPC (return errors)
 func (c *cmdProxy) StdinPipe() (io.WriteCloser, error) {
-	return nil, fmt.Errorf("StdinPipe not supported over IPC")
+	enc := ipc.NewEncoder()
+	enc.Uint64(c.handle)
+	resp, err := c.client.Call(ipc.MsgCmdStdinPipe, enc.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	dec := ipc.NewDecoder(resp)
+	if ipcErr, err := ipc.DecodeError(dec); err != nil {
+		return nil, err
+	} else if ipcErr != nil {
+		return nil, ipcErr
+	}
+	pipeHandle, _ := dec.Uint64()
+	return &connProxy{client: c.client, handle: pipeHandle}, nil
 }
 
 func (c *cmdProxy) StdoutPipe() (io.ReadCloser, error) {
-	return nil, fmt.Errorf("StdoutPipe not supported over IPC")
+	enc := ipc.NewEncoder()
+	enc.Uint64(c.handle)
+	resp, err := c.client.Call(ipc.MsgCmdStdoutPipe, enc.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	dec := ipc.NewDecoder(resp)
+	if ipcErr, err := ipc.DecodeError(dec); err != nil {
+		return nil, err
+	} else if ipcErr != nil {
+		return nil, ipcErr
+	}
+	pipeHandle, _ := dec.Uint64()
+	return &connProxy{client: c.client, handle: pipeHandle}, nil
 }
 
 func (c *cmdProxy) StderrPipe() (io.ReadCloser, error) {
-	return nil, fmt.Errorf("StderrPipe not supported over IPC")
+	enc := ipc.NewEncoder()
+	enc.Uint64(c.handle)
+	resp, err := c.client.Call(ipc.MsgCmdStderrPipe, enc.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	dec := ipc.NewDecoder(resp)
+	if ipcErr, err := ipc.DecodeError(dec); err != nil {
+		return nil, err
+	} else if ipcErr != nil {
+		return nil, ipcErr
+	}
+	pipeHandle, _ := dec.Uint64()
+	return &connProxy{client: c.client, handle: pipeHandle}, nil
 }
 
 func (c *cmdProxy) SetStdin(r io.Reader) cc.Cmd {

--- a/bindings/python/crumblecracker/client.py
+++ b/bindings/python/crumblecracker/client.py
@@ -5,6 +5,7 @@ OCI client for pulling and managing container images.
 from __future__ import annotations
 
 import ctypes
+import platform
 from ctypes import POINTER, byref, c_char_p
 from typing import TYPE_CHECKING, Any
 
@@ -69,9 +70,19 @@ class InstanceSource:
     def get_config(self) -> ImageConfig:
         """Get the image configuration."""
         if _ffi.using_ipc():
-            # Image config is not available via IPC in the current protocol
+            # IPC currently doesn't expose source config over the wire.
+            # Return a best-effort config with host architecture filled in.
+            machine = platform.machine().lower()
+            arch_map = {
+                "x86_64": "amd64",
+                "amd64": "amd64",
+                "aarch64": "arm64",
+                "arm64": "arm64",
+            }
             return ImageConfig(
-                architecture=None, env=[], working_dir=None,
+                architecture=arch_map.get(machine, machine),
+                env=[],
+                working_dir=None,
                 entrypoint=[], cmd=[], user=None,
             )
 

--- a/internal/api/ipc_proxy.go
+++ b/internal/api/ipc_proxy.go
@@ -691,15 +691,48 @@ func (c *cmdIPCProxy) ExitCode() int {
 }
 
 func (c *cmdIPCProxy) StdinPipe() (io.WriteCloser, error) {
-	return nil, fmt.Errorf("StdinPipe not supported over IPC")
+	enc := ipc.NewEncoder()
+	enc.Uint64(c.handle)
+	resp, err := c.client.Call(ipc.MsgCmdStdinPipe, enc.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	dec, err := decodeError(resp)
+	if err != nil {
+		return nil, err
+	}
+	pipeHandle, _ := dec.Uint64()
+	return &connIPCProxy{client: c.client, handle: pipeHandle}, nil
 }
 
 func (c *cmdIPCProxy) StdoutPipe() (io.ReadCloser, error) {
-	return nil, fmt.Errorf("StdoutPipe not supported over IPC")
+	enc := ipc.NewEncoder()
+	enc.Uint64(c.handle)
+	resp, err := c.client.Call(ipc.MsgCmdStdoutPipe, enc.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	dec, err := decodeError(resp)
+	if err != nil {
+		return nil, err
+	}
+	pipeHandle, _ := dec.Uint64()
+	return &connIPCProxy{client: c.client, handle: pipeHandle}, nil
 }
 
 func (c *cmdIPCProxy) StderrPipe() (io.ReadCloser, error) {
-	return nil, fmt.Errorf("StderrPipe not supported over IPC")
+	enc := ipc.NewEncoder()
+	enc.Uint64(c.handle)
+	resp, err := c.client.Call(ipc.MsgCmdStderrPipe, enc.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	dec, err := decodeError(resp)
+	if err != nil {
+		return nil, err
+	}
+	pipeHandle, _ := dec.Uint64()
+	return &connIPCProxy{client: c.client, handle: pipeHandle}, nil
 }
 
 func (c *cmdIPCProxy) SetStdin(_ io.Reader) Cmd  { return c }

--- a/internal/helper/handlers.go
+++ b/internal/helper/handlers.go
@@ -1551,7 +1551,7 @@ func (h *Helper) handleCmdStdoutPipe(dec *ipc.Decoder) ([]byte, error) {
 		return nil, errorToIPC(err)
 	}
 
-	pipeHandle := h.nextHandle.Add(1)
+	pipeHandle := h.newHandle()
 	h.mu.Lock()
 	h.pipeRds[pipeHandle] = reader
 	h.mu.Unlock()
@@ -1578,7 +1578,7 @@ func (h *Helper) handleCmdStderrPipe(dec *ipc.Decoder) ([]byte, error) {
 		return nil, errorToIPC(err)
 	}
 
-	pipeHandle := h.nextHandle.Add(1)
+	pipeHandle := h.newHandle()
 	h.mu.Lock()
 	h.pipeRds[pipeHandle] = reader
 	h.mu.Unlock()
@@ -1605,7 +1605,7 @@ func (h *Helper) handleCmdStdinPipe(dec *ipc.Decoder) ([]byte, error) {
 		return nil, errorToIPC(err)
 	}
 
-	pipeHandle := h.nextHandle.Add(1)
+	pipeHandle := h.newHandle()
 	h.mu.Lock()
 	h.pipeWrs[pipeHandle] = writer
 	h.mu.Unlock()

--- a/internal/helper/handlers.go
+++ b/internal/helper/handlers.go
@@ -73,6 +73,22 @@ func (h *Helper) Close() error {
 	}
 	h.conns = nil
 
+	// Close all command pipe readers
+	for _, r := range h.pipeRds {
+		if err := r.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	h.pipeRds = nil
+
+	// Close all command pipe writers
+	for _, w := range h.pipeWrs {
+		if err := w.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	h.pipeWrs = nil
+
 	// Close all listeners
 	for _, l := range h.listeners {
 		if err := l.Close(); err != nil {
@@ -1756,16 +1772,21 @@ func (h *Helper) handleConnRead(dec *ipc.Decoder) ([]byte, error) {
 		return nil, err
 	}
 
+	buf := make([]byte, length)
+
 	h.mu.RLock()
-	conn, ok := h.conns[handle]
+	conn, connOK := h.conns[handle]
+	pipeRd, pipeOK := h.pipeRds[handle]
 	h.mu.RUnlock()
 
-	if !ok {
+	var n int
+	if connOK {
+		n, err = conn.Read(buf)
+	} else if pipeOK {
+		n, err = pipeRd.Read(buf)
+	} else {
 		return nil, &ipc.IPCError{Code: ipc.ErrCodeInvalidHandle, Message: "invalid conn handle"}
 	}
-
-	buf := make([]byte, length)
-	n, err := conn.Read(buf)
 	if err != nil {
 		return nil, errorToIPC(err)
 	}
@@ -1784,14 +1805,18 @@ func (h *Helper) handleConnWrite(dec *ipc.Decoder) ([]byte, error) {
 	}
 
 	h.mu.RLock()
-	conn, ok := h.conns[handle]
+	conn, connOK := h.conns[handle]
+	pipeWr, pipeOK := h.pipeWrs[handle]
 	h.mu.RUnlock()
 
-	if !ok {
+	var n int
+	if connOK {
+		n, err = conn.Write(data)
+	} else if pipeOK {
+		n, err = pipeWr.Write(data)
+	} else {
 		return nil, &ipc.IPCError{Code: ipc.ErrCodeInvalidHandle, Message: "invalid conn handle"}
 	}
-
-	n, err := conn.Write(data)
 	if err != nil {
 		return nil, errorToIPC(err)
 	}
@@ -1806,18 +1831,35 @@ func (h *Helper) handleConnClose(dec *ipc.Decoder) ([]byte, error) {
 	}
 
 	h.mu.Lock()
-	conn, ok := h.conns[handle]
-	if ok {
+	conn, connOK := h.conns[handle]
+	if connOK {
 		delete(h.conns, handle)
+	}
+	pipeRd, pipeRdOK := h.pipeRds[handle]
+	if pipeRdOK {
+		delete(h.pipeRds, handle)
+	}
+	pipeWr, pipeWrOK := h.pipeWrs[handle]
+	if pipeWrOK {
+		delete(h.pipeWrs, handle)
 	}
 	h.mu.Unlock()
 
-	if !ok {
+	switch {
+	case connOK:
+		if err := conn.Close(); err != nil {
+			return nil, errorToIPC(err)
+		}
+	case pipeRdOK:
+		if err := pipeRd.Close(); err != nil {
+			return nil, errorToIPC(err)
+		}
+	case pipeWrOK:
+		if err := pipeWr.Close(); err != nil {
+			return nil, errorToIPC(err)
+		}
+	default:
 		return nil, &ipc.IPCError{Code: ipc.ErrCodeInvalidHandle, Message: "invalid conn handle"}
-	}
-
-	if err := conn.Close(); err != nil {
-		return nil, errorToIPC(err)
 	}
 
 	return ipc.NewResponseBuilder().Success().Build(), nil
@@ -1830,14 +1872,18 @@ func (h *Helper) handleConnLocalAddr(dec *ipc.Decoder) ([]byte, error) {
 	}
 
 	h.mu.RLock()
-	conn, ok := h.conns[handle]
+	conn, connOK := h.conns[handle]
+	_, pipeRdOK := h.pipeRds[handle]
+	_, pipeWrOK := h.pipeWrs[handle]
 	h.mu.RUnlock()
 
-	if !ok {
-		return nil, &ipc.IPCError{Code: ipc.ErrCodeInvalidHandle, Message: "invalid conn handle"}
+	if connOK {
+		return ipc.NewResponseBuilder().Success().String(conn.LocalAddr().String()).Build(), nil
 	}
-
-	return ipc.NewResponseBuilder().Success().String(conn.LocalAddr().String()).Build(), nil
+	if pipeRdOK || pipeWrOK {
+		return ipc.NewResponseBuilder().Success().String("pipe").Build(), nil
+	}
+	return nil, &ipc.IPCError{Code: ipc.ErrCodeInvalidHandle, Message: "invalid conn handle"}
 }
 
 func (h *Helper) handleConnRemoteAddr(dec *ipc.Decoder) ([]byte, error) {
@@ -1847,14 +1893,18 @@ func (h *Helper) handleConnRemoteAddr(dec *ipc.Decoder) ([]byte, error) {
 	}
 
 	h.mu.RLock()
-	conn, ok := h.conns[handle]
+	conn, connOK := h.conns[handle]
+	_, pipeRdOK := h.pipeRds[handle]
+	_, pipeWrOK := h.pipeWrs[handle]
 	h.mu.RUnlock()
 
-	if !ok {
-		return nil, &ipc.IPCError{Code: ipc.ErrCodeInvalidHandle, Message: "invalid conn handle"}
+	if connOK {
+		return ipc.NewResponseBuilder().Success().String(conn.RemoteAddr().String()).Build(), nil
 	}
-
-	return ipc.NewResponseBuilder().Success().String(conn.RemoteAddr().String()).Build(), nil
+	if pipeRdOK || pipeWrOK {
+		return ipc.NewResponseBuilder().Success().String("pipe").Build(), nil
+	}
+	return nil, &ipc.IPCError{Code: ipc.ErrCodeInvalidHandle, Message: "invalid conn handle"}
 }
 
 // ==========================================================================

--- a/internal/helper/handlers_pipe_test.go
+++ b/internal/helper/handlers_pipe_test.go
@@ -1,0 +1,140 @@
+package helper
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/tinyrange/cc/internal/ipc"
+)
+
+type testWriteCloser struct {
+	buf    bytes.Buffer
+	closed bool
+}
+
+func (w *testWriteCloser) Write(p []byte) (int, error) {
+	return w.buf.Write(p)
+}
+
+func (w *testWriteCloser) Close() error {
+	w.closed = true
+	return nil
+}
+
+func decodeSuccess(t *testing.T, payload []byte) *ipc.Decoder {
+	t.Helper()
+
+	dec := ipc.NewDecoder(payload)
+	ipcErr, err := ipc.DecodeError(dec)
+	if err != nil {
+		t.Fatalf("DecodeError: %v", err)
+	}
+	if ipcErr != nil {
+		t.Fatalf("unexpected IPC error: %v", ipcErr)
+	}
+	return dec
+}
+
+func TestHandleConnReadFromPipe(t *testing.T) {
+	h := NewHelper()
+	handle := h.newHandle()
+	h.pipeRds[handle] = io.NopCloser(bytes.NewReader([]byte("hello from pipe")))
+
+	req := ipc.NewEncoder()
+	req.Uint64(handle)
+	req.Uint32(128)
+
+	resp, err := h.handleConnRead(ipc.NewDecoder(req.Bytes()))
+	if err != nil {
+		t.Fatalf("handleConnRead: %v", err)
+	}
+
+	dec := decodeSuccess(t, resp)
+	data, err := dec.Bytes()
+	if err != nil {
+		t.Fatalf("Bytes: %v", err)
+	}
+	if got, want := string(data), "hello from pipe"; got != want {
+		t.Fatalf("read mismatch: got %q, want %q", got, want)
+	}
+}
+
+func TestHandleConnWriteAndClosePipe(t *testing.T) {
+	h := NewHelper()
+	handle := h.newHandle()
+	w := &testWriteCloser{}
+	h.pipeWrs[handle] = w
+
+	reqWrite := ipc.NewEncoder()
+	reqWrite.Uint64(handle)
+	reqWrite.WriteBytes([]byte("stdin payload"))
+
+	resp, err := h.handleConnWrite(ipc.NewDecoder(reqWrite.Bytes()))
+	if err != nil {
+		t.Fatalf("handleConnWrite: %v", err)
+	}
+
+	dec := decodeSuccess(t, resp)
+	n, err := dec.Uint32()
+	if err != nil {
+		t.Fatalf("Uint32: %v", err)
+	}
+	if got, want := int(n), len("stdin payload"); got != want {
+		t.Fatalf("write size mismatch: got %d, want %d", got, want)
+	}
+	if got, want := w.buf.String(), "stdin payload"; got != want {
+		t.Fatalf("write payload mismatch: got %q, want %q", got, want)
+	}
+
+	reqClose := ipc.NewEncoder()
+	reqClose.Uint64(handle)
+
+	resp, err = h.handleConnClose(ipc.NewDecoder(reqClose.Bytes()))
+	if err != nil {
+		t.Fatalf("handleConnClose: %v", err)
+	}
+	_ = decodeSuccess(t, resp)
+
+	if !w.closed {
+		t.Fatal("expected pipe writer to be closed")
+	}
+	if _, ok := h.pipeWrs[handle]; ok {
+		t.Fatal("expected pipe writer handle to be removed")
+	}
+}
+
+func TestHandleConnAddrForPipe(t *testing.T) {
+	h := NewHelper()
+	handle := h.newHandle()
+	h.pipeRds[handle] = io.NopCloser(bytes.NewReader(nil))
+
+	req := ipc.NewEncoder()
+	req.Uint64(handle)
+
+	localResp, err := h.handleConnLocalAddr(ipc.NewDecoder(req.Bytes()))
+	if err != nil {
+		t.Fatalf("handleConnLocalAddr: %v", err)
+	}
+	localDec := decodeSuccess(t, localResp)
+	localAddr, err := localDec.String()
+	if err != nil {
+		t.Fatalf("String(local): %v", err)
+	}
+	if localAddr != "pipe" {
+		t.Fatalf("local addr mismatch: got %q, want %q", localAddr, "pipe")
+	}
+
+	remoteResp, err := h.handleConnRemoteAddr(ipc.NewDecoder(req.Bytes()))
+	if err != nil {
+		t.Fatalf("handleConnRemoteAddr: %v", err)
+	}
+	remoteDec := decodeSuccess(t, remoteResp)
+	remoteAddr, err := remoteDec.String()
+	if err != nil {
+		t.Fatalf("String(remote): %v", err)
+	}
+	if remoteAddr != "pipe" {
+		t.Fatalf("remote addr mismatch: got %q, want %q", remoteAddr, "pipe")
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches IPC protocol plumbing and helper handle lifecycle; mistakes could cause deadlocks, invalid-handle errors, or resource leaks when streaming command I/O.
> 
> **Overview**
> Enables `Cmd.StdinPipe`/`StdoutPipe`/`StderrPipe` when using the IPC backend by adding IPC calls that return pipe handles and proxying them through existing `conn*Proxy` read/write/close operations.
> 
> Updates `cc-helper` handle management and cleanup to track pipe readers/writers, route `MsgConnRead`/`MsgConnWrite`/`MsgConnClose`/addr queries to either network conns or command pipes, and adds focused unit tests for the new pipe behavior.
> 
> In Python IPC mode, `InstanceSource.get_config()` now returns a best-effort `ImageConfig` with host architecture filled in (instead of `None`) since config isn’t currently available over the IPC protocol.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c3114c2dbd9ab582b9a6f0824bbca45385ee9d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->